### PR TITLE
Add option property disableImageCheck

### DIFF
--- a/__tests__/base-pass.ts
+++ b/__tests__/base-pass.ts
@@ -55,6 +55,7 @@ describe('PassBase', () => {
 
     const bpWithAllowHttpFalse = new PassBase({}, undefined, undefined, {
       allowHttp: false,
+      disableImageCheck: false,
     });
     expect(() => {
       bpWithAllowHttpFalse.webServiceURL = 'http://transfers.do/webservice';
@@ -62,6 +63,7 @@ describe('PassBase', () => {
 
     const bpWithAllowHttpTrue = new PassBase({}, undefined, undefined, {
       allowHttp: true,
+      disableImageCheck: false,
     });
     expect(() => {
       bpWithAllowHttpTrue.webServiceURL = 'http://transfers.do/webservice';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -448,6 +448,7 @@ export type ApplePass = PassStandardKeys &
   PassWebServiceKeys &
   PassStructureFields;
 
-  export interface Options {
-    allowHttp: boolean
-  }
+export interface Options {
+  allowHttp: boolean;
+  disableImageCheck: boolean;
+}

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -73,9 +73,10 @@ export class PassImages extends Map<string, string | Buffer> {
    * loaded, nothing bad happens if directory contains other files.
    *
    * @param {string} dirPath - path to a directory with images
+   * @param {boolean} disableImageCheck - disable image dimension validation
    * @memberof PassImages
    */
-  async load(dirPath: string): Promise<this> {
+  async load(dirPath: string, disableImageCheck?: boolean): Promise<this> {
     // Check if the path is accessible directory actually
     const entries = await fs.readdir(dirPath, { withFileTypes: true });
     // checking rest of files
@@ -101,6 +102,7 @@ export class PassImages extends Map<string, string | Buffer> {
                 path.join(currentPath, f.name),
                 img.density,
                 lang,
+                disableImageCheck
               ),
             );
         }
@@ -113,6 +115,8 @@ export class PassImages extends Map<string, string | Buffer> {
               img.imageType,
               path.join(dirPath, entry.name),
               img.density,
+              undefined,
+              disableImageCheck
             ),
           );
       }
@@ -121,11 +125,13 @@ export class PassImages extends Map<string, string | Buffer> {
     return this;
   }
 
+  // eslint-disable-line max-params
   async add(
     imageType: ImageType,
     pathOrBuffer: string | Buffer,
     density?: ImageDensity,
     lang?: string,
+    disableImageCheck?: boolean
   ): Promise<void> {
     if (!IMAGES_TYPES.has(imageType))
       throw new TypeError(`Unknown image type ${imageSize} for ${imageType}`);
@@ -154,7 +160,7 @@ export class PassImages extends Map<string, string | Buffer> {
         );
       sizeRes = parser.getResult() as ImageSizeResult;
     }
-    this.checkImage(imageType, sizeRes, density);
+    if (!disableImageCheck) this.checkImage(imageType, sizeRes, density);
     super.set(this.getImageFilename(imageType, density, lang), pathOrBuffer);
   }
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -130,6 +130,7 @@ export class Template extends PassBase {
                 join(currentPath, f.name),
                 img.density,
                 lang,
+                options?.disableImageCheck
               ),
             );
         }
@@ -150,6 +151,8 @@ export class Template extends PassBase {
               img.imageType,
               join(folderPath, entry.name),
               img.density,
+              undefined,
+              options?.disableImageCheck
             ),
           );
       }
@@ -211,6 +214,7 @@ export class Template extends PassBase {
             imgBuffer,
             img.density,
             img.lang,
+            options?.disableImageCheck,
           );
         } else {
           // the only option lest is 'pass.strings' file in localization folder
@@ -362,6 +366,6 @@ export class Template extends PassBase {
   }
 }
 
-function createDefaultTemplate(options?: Options): Template{
+function createDefaultTemplate(options?: Options): Template {
   return new Template(undefined, {}, undefined, undefined, options)
 }


### PR DESCRIPTION
This PR allows to skip checking the dimensions of the images provided to the library. I had some issues especially around the logo which I think the library currently is too strict regarding the maximum width allowed. Nevertheless I expanded the options that can be provided to the library to include the property `disableImageCheck` so that a user of the library can decide if the image dimension validation should be skipped or not without altering the default behaviour if nothing is passed.