### PR TITLE
feat: add iOS 18 / iOS 26 pass keys and typed SemanticTags

### DIFF
--- a/__tests__/base-pass.ts
+++ b/__tests__/base-pass.ts
@@ -195,6 +195,278 @@ describe('PassBase', () => {
     assert.equal(bp.appLaunchURL, undefined);
   });
 
+  it('P0 iOS 18 event-ticket URL setters round-trip', () => {
+    const urlFields = [
+      'bagPolicyURL',
+      'orderFoodURL',
+      'parkingInformationURL',
+      'directionsInformationURL',
+      'purchaseParkingURL',
+      'merchandiseURL',
+      'transitInformationURL',
+      'accessibilityURL',
+      'addOnURL',
+      'contactVenueWebsite',
+      'transferURL',
+      'sellURL',
+    ] as const;
+    const bp = new PassBase({ eventTicket: {} }) as unknown as Record<
+      string,
+      string | undefined
+    >;
+    for (const key of urlFields) {
+      assert.equal(bp[key], undefined, `${key} should start undefined`);
+      const url = `https://example.com/${key}`;
+      bp[key] = url;
+      assert.equal(bp[key], url, `${key} should persist the set value`);
+      assert.match(
+        JSON.stringify(bp),
+        new RegExp(`"${key}":"https://example.com/${key}"`),
+        `${key} should serialize into pass.json`,
+      );
+      bp[key] = undefined;
+      assert.equal(bp[key], undefined, `${key} should clear on undefined`);
+    }
+    // Malformed URL throws for every setter.
+    for (const key of urlFields) {
+      assert.throws(
+        () => {
+          bp[key] = '/not-a-url';
+        },
+        TypeError,
+        `${key} should reject malformed URL`,
+      );
+    }
+  });
+
+  it('P0 iOS 18 event-ticket plain-string setters', () => {
+    const bp = new PassBase();
+    bp.contactVenueEmail = 'venue@example.com';
+    bp.contactVenuePhoneNumber = '+1-555-0100';
+    bp.eventLogoText = 'World Cup 2026';
+    assert.equal(bp.contactVenueEmail, 'venue@example.com');
+    assert.equal(bp.contactVenuePhoneNumber, '+1-555-0100');
+    assert.equal(bp.eventLogoText, 'World Cup 2026');
+    const json = JSON.parse(JSON.stringify(bp));
+    assert.equal(json.contactVenueEmail, 'venue@example.com');
+    assert.equal(json.contactVenuePhoneNumber, '+1-555-0100');
+    assert.equal(json.eventLogoText, 'World Cup 2026');
+    // Delete-on-empty.
+    bp.contactVenueEmail = undefined;
+    bp.contactVenuePhoneNumber = undefined;
+    bp.eventLogoText = undefined;
+    const json2 = JSON.parse(JSON.stringify(bp));
+    assert.equal(json2.contactVenueEmail, undefined);
+    assert.equal(json2.contactVenuePhoneNumber, undefined);
+    assert.equal(json2.eventLogoText, undefined);
+  });
+
+  it('P0 iOS 18 event-ticket boolean setters', () => {
+    const bp = new PassBase();
+    assert.equal(bp.suppressHeaderDarkening, false);
+    assert.equal(bp.useAutomaticColors, false);
+    bp.suppressHeaderDarkening = true;
+    bp.useAutomaticColors = true;
+    const on = JSON.parse(JSON.stringify(bp));
+    assert.equal(on.suppressHeaderDarkening, true);
+    assert.equal(on.useAutomaticColors, true);
+    // false deletes
+    bp.suppressHeaderDarkening = false;
+    bp.useAutomaticColors = false;
+    const off = JSON.parse(JSON.stringify(bp));
+    assert.equal(off.suppressHeaderDarkening, undefined);
+    assert.equal(off.useAutomaticColors, undefined);
+  });
+
+  it('P0 auxiliaryStoreIdentifiers filters to integers', () => {
+    const bp = new PassBase();
+    bp.auxiliaryStoreIdentifiers = [1, 2.5, 3, 'x' as unknown as number];
+    assert.deepEqual(bp.auxiliaryStoreIdentifiers, [1, 3]);
+    // Empty effective array deletes.
+    bp.auxiliaryStoreIdentifiers = [2.5, 'x' as unknown as number];
+    assert.equal(bp.auxiliaryStoreIdentifiers, undefined);
+    bp.auxiliaryStoreIdentifiers = undefined;
+    assert.equal(bp.auxiliaryStoreIdentifiers, undefined);
+  });
+
+  it('P0 footerBackgroundColor accepts PassColor inputs', () => {
+    const bp = new PassBase();
+    assert.equal(bp.footerBackgroundColor, undefined);
+    bp.footerBackgroundColor = '#FF0000';
+    assert.deepEqual(Array.from(bp.footerBackgroundColor!), [255, 0, 0]);
+    bp.footerBackgroundColor = 'rgb(0, 128, 0)';
+    assert.deepEqual(Array.from(bp.footerBackgroundColor!), [0, 128, 0]);
+    bp.footerBackgroundColor = 'navy';
+    assert.deepEqual(Array.from(bp.footerBackgroundColor!), [0, 0, 128]);
+    assert.throws(() => {
+      bp.footerBackgroundColor = 'not-a-color';
+    }, /Invalid color value/);
+    bp.footerBackgroundColor = undefined;
+    assert.equal(bp.footerBackgroundColor, undefined);
+  });
+
+  it('P0 additionalInfoFields is gated on eventTicket', () => {
+    // storeCard should throw on access
+    const store = new PassBase({ storeCard: {} });
+    assert.throws(
+      () => store.additionalInfoFields,
+      /only allowed on eventTicket/,
+    );
+    // eventTicket should allow add + serialize
+    const evt = new PassBase({ eventTicket: {} });
+    evt.additionalInfoFields.add({ key: 'info', value: 'See our FAQ' });
+    const json = JSON.parse(JSON.stringify(evt));
+    assert.deepEqual(json.eventTicket.additionalInfoFields, [
+      { key: 'info', value: 'See our FAQ' },
+    ]);
+    // Constructor-side hydration also works.
+    const evt2 = new PassBase({
+      eventTicket: {
+        additionalInfoFields: [{ key: 'info2', value: 'Rules apply' }],
+      },
+    });
+    assert.equal(evt2.additionalInfoFields.size, 1);
+  });
+
+  it('P0 preferredStyleSchemes accepts iOS 26 schemes', () => {
+    const bp = new PassBase({
+      boardingPass: { transitType: 'PKTransitTypeAir' },
+    });
+    bp.preferredStyleSchemes = ['semanticBoardingPass', 'boardingPass'];
+    const json = JSON.parse(JSON.stringify(bp));
+    assert.deepEqual(json.preferredStyleSchemes, [
+      'semanticBoardingPass',
+      'boardingPass',
+    ]);
+  });
+
+  it('P0 typed SemanticTags (iOS 18 fields) compile + serialize', () => {
+    const eventStart = new Date(Date.UTC(2026, 5, 1, 20, 0, 0));
+    const bp = new PassBase({
+      eventTicket: {},
+      semantics: {
+        admissionLevel: 'VIP',
+        admissionLevelAbbreviation: 'VIP',
+        entranceDescription: 'Main entrance',
+        venueOpenDate: eventStart,
+        eventStartDateInfo: {
+          date: eventStart,
+          timeZone: 'America/Chicago',
+          unannounced: true,
+        },
+        seats: [
+          {
+            seatSection: 'A',
+            seatRow: '12',
+            seatNumber: '7',
+            seatAisle: 'Left',
+            seatLevel: '2',
+            seatSectionColor: '#FF0000',
+          },
+        ],
+        tailgatingAllowed: true,
+      },
+    });
+    const json = JSON.parse(JSON.stringify(bp));
+    assert.equal(json.semantics.admissionLevel, 'VIP');
+    assert.equal(json.semantics.tailgatingAllowed, true);
+    assert.equal(json.semantics.seats[0].seatSectionColor, '#FF0000');
+    // venueOpenDate is a Date in input → W3C string in output.
+    assert.match(
+      json.semantics.venueOpenDate,
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?(?:[+-]\d{2}:\d{2}|Z)$/,
+    );
+    assert.equal(json.semantics.eventStartDateInfo.timeZone, 'America/Chicago');
+    assert.equal(json.semantics.eventStartDateInfo.unannounced, true);
+  });
+
+  it('P1 iOS 26 enhanced boarding-pass URL setters round-trip', () => {
+    const urlFields = [
+      'changeSeatURL',
+      'entertainmentURL',
+      'purchaseAdditionalBaggageURL',
+      'purchaseLoungeAccessURL',
+      'purchaseWifiURL',
+      'upgradeURL',
+      'managementURL',
+      'registerServiceAnimalURL',
+      'reportLostBagURL',
+      'requestWheelchairURL',
+      'transitProviderWebsiteURL',
+    ] as const;
+    const bp = new PassBase({
+      boardingPass: { transitType: 'PKTransitTypeAir' },
+    }) as unknown as Record<string, string | undefined>;
+    for (const key of urlFields) {
+      assert.equal(bp[key], undefined);
+      const url = `https://airline.example/${key}`;
+      bp[key] = url;
+      assert.equal(bp[key], url);
+      assert.match(JSON.stringify(bp), new RegExp(`"${key}":"${url}"`));
+      bp[key] = undefined;
+      assert.equal(bp[key], undefined);
+      assert.throws(() => {
+        bp[key] = '/nope';
+      }, TypeError);
+    }
+  });
+
+  it('P1 iOS 26 transit provider contact setters', () => {
+    const bp = new PassBase({
+      boardingPass: { transitType: 'PKTransitTypeAir' },
+    });
+    bp.transitProviderEmail = 'support@airline.example';
+    bp.transitProviderPhoneNumber = '+1-800-FLY-AWAY';
+    assert.equal(bp.transitProviderEmail, 'support@airline.example');
+    assert.equal(bp.transitProviderPhoneNumber, '+1-800-FLY-AWAY');
+    bp.transitProviderEmail = undefined;
+    bp.transitProviderPhoneNumber = undefined;
+    const json = JSON.parse(JSON.stringify(bp));
+    assert.equal(json.transitProviderEmail, undefined);
+    assert.equal(json.transitProviderPhoneNumber, undefined);
+  });
+
+  it('P1 typed SemanticTags (iOS 26 fields) compile + serialize', () => {
+    const bp = new PassBase({
+      boardingPass: { transitType: 'PKTransitTypeAir' },
+      semantics: {
+        boardingZone: '3',
+        departureCityName: 'London',
+        destinationCityName: 'Shanghai',
+        departureLocationTimeZone: 'Europe/London',
+        destinationLocationTimeZone: 'Asia/Shanghai',
+        passengerCapabilities: [
+          'PKPassengerCapabilityPreboarding',
+          'PKPassengerCapabilityPriorityBoarding',
+        ],
+        passengerEligibleSecurityPrograms: [
+          'PKTransitSecurityProgramTSAPreCheck',
+          'PKTransitSecurityProgramGlobalEntry',
+        ],
+        departureLocationSecurityPrograms: [
+          'PKTransitSecurityProgramTSAPreCheck',
+        ],
+        destinationLocationSecurityPrograms: ['PKTransitSecurityProgramCLEAR'],
+        ticketFareClass: 'Economy',
+        membershipProgramStatus: 'Gold',
+        loungePlaceIDs: ['I123456', 'I654321'],
+        passengerAirlineSSRs: ['MEAL'],
+        passengerInformationSSRs: ['FQTV'],
+        passengerServiceSSRs: ['WCHR'],
+        internationalDocumentsAreVerified: true,
+        internationalDocumentsVerifiedDeclarationName: 'DOCS OK',
+      },
+    });
+    const json = JSON.parse(JSON.stringify(bp));
+    assert.equal(json.semantics.boardingZone, '3');
+    assert.deepEqual(json.semantics.passengerCapabilities, [
+      'PKPassengerCapabilityPreboarding',
+      'PKPassengerCapabilityPriorityBoarding',
+    ]);
+    assert.equal(json.semantics.ticketFareClass, 'Economy');
+    assert.equal(json.semantics.internationalDocumentsAreVerified, true);
+  });
+
   it('color values as RGB triplets', () => {
     const bp = new PassBase();
     assert.doesNotThrow(() => {

--- a/__tests__/upcoming-pass-information.ts
+++ b/__tests__/upcoming-pass-information.ts
@@ -166,6 +166,34 @@ describe('upcomingPassInformation', () => {
     }
   });
 
+  it('setter throws on invalid image scale', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    for (const bad of [0, 4, 1.5, -1, Number.NaN]) {
+      assert.throws(
+        () => {
+          bp.upcomingPassInformation = [
+            baseEntry({
+              images: {
+                headerImage: {
+                  URLs: [
+                    {
+                      URL: 'https://cdn.example/header.png',
+                      SHA256,
+                      scale: bad as 1 | 2 | 3,
+                    },
+                  ],
+                },
+              },
+            }),
+          ];
+        },
+        /scale must be 1, 2, or 3/,
+        `scale=${bad} should throw`,
+      );
+    }
+  });
+
   it('setter throws on non-https image URL', () => {
     const bp = new PassBase({ eventTicket: {} });
     bp.preferredStyleSchemes = ['posterEventTicket'];

--- a/__tests__/upcoming-pass-information.ts
+++ b/__tests__/upcoming-pass-information.ts
@@ -5,12 +5,11 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { PassBase } from '../dist/lib/base-pass.js';
+import { assertUpcomingPassInformationContext } from '../dist/lib/upcoming-pass-information.js';
 import type { UpcomingPassInformationEntry } from '../dist/lib/upcoming-pass-information.js';
 
 // Valid 64-char lowercase-hex digest used across tests.
-const SHA256 = 'a'.repeat(
-  64,
-) as UpcomingPassInformationEntry['images'] extends object ? string : string;
+const SHA256 = 'a'.repeat(64);
 
 function baseEntry(
   overrides: Partial<UpcomingPassInformationEntry> = {},
@@ -62,30 +61,9 @@ describe('upcomingPassInformation', () => {
     assert.equal(entry.images.headerImage.URLs[0].SHA256, SHA256);
   });
 
-  it('throws when pass style is not eventTicket', () => {
-    const bp = new PassBase({ storeCard: {} });
-    bp.preferredStyleSchemes = ['posterEventTicket'];
-    assert.throws(() => {
-      bp.upcomingPassInformation = [baseEntry()];
-    }, /requires style "eventTicket"/);
-  });
+  // ─── Per-entry shape (setter-time) ───────────────────────────────────
 
-  it('throws when preferredStyleSchemes is missing posterEventTicket', () => {
-    const bp = new PassBase({ eventTicket: {} });
-    bp.preferredStyleSchemes = ['eventTicket'];
-    assert.throws(() => {
-      bp.upcomingPassInformation = [baseEntry()];
-    }, /preferredStyleSchemes to include "posterEventTicket"/);
-  });
-
-  it('throws when preferredStyleSchemes is unset', () => {
-    const bp = new PassBase({ eventTicket: {} });
-    assert.throws(() => {
-      bp.upcomingPassInformation = [baseEntry()];
-    }, /preferredStyleSchemes to include "posterEventTicket"/);
-  });
-
-  it('throws when identifier is empty', () => {
+  it('setter throws when identifier is empty', () => {
     const bp = new PassBase({ eventTicket: {} });
     bp.preferredStyleSchemes = ['posterEventTicket'];
     assert.throws(() => {
@@ -93,7 +71,7 @@ describe('upcomingPassInformation', () => {
     }, /\.identifier must be a non-empty string/);
   });
 
-  it('throws when name is missing', () => {
+  it('setter throws when name is missing', () => {
     const bp = new PassBase({ eventTicket: {} });
     bp.preferredStyleSchemes = ['posterEventTicket'];
     assert.throws(() => {
@@ -105,7 +83,7 @@ describe('upcomingPassInformation', () => {
     }, /\.name must be a non-empty string/);
   });
 
-  it('throws when type is not "event"', () => {
+  it('setter throws when type is not "event"', () => {
     const bp = new PassBase({ eventTicket: {} });
     bp.preferredStyleSchemes = ['posterEventTicket'];
     assert.throws(() => {
@@ -117,7 +95,7 @@ describe('upcomingPassInformation', () => {
     }, /\.type must be "event"/);
   });
 
-  it('throws on bad SHA256', () => {
+  it('setter throws on bad SHA256', () => {
     const bp = new PassBase({ eventTicket: {} });
     bp.preferredStyleSchemes = ['posterEventTicket'];
     assert.throws(() => {
@@ -138,7 +116,7 @@ describe('upcomingPassInformation', () => {
     }, /SHA256 must be a 64-char hex string/);
   });
 
-  it('throws on oversize image (> 2 MiB)', () => {
+  it('setter throws on oversize image (> 2 MiB)', () => {
     const bp = new PassBase({ eventTicket: {} });
     bp.preferredStyleSchemes = ['posterEventTicket'];
     assert.throws(() => {
@@ -160,7 +138,56 @@ describe('upcomingPassInformation', () => {
     }, /size exceeds 2 MiB/);
   });
 
-  it('throws on malformed image URL', () => {
+  it('setter throws on invalid image size (negative, NaN, fractional)', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    for (const bad of [-1, Number.NaN, 1.5, Number.POSITIVE_INFINITY]) {
+      assert.throws(
+        () => {
+          bp.upcomingPassInformation = [
+            baseEntry({
+              images: {
+                headerImage: {
+                  URLs: [
+                    {
+                      URL: 'https://cdn.example/header.png',
+                      SHA256,
+                      size: bad,
+                    },
+                  ],
+                },
+              },
+            }),
+          ];
+        },
+        /size must be a non-negative integer/,
+        `size=${bad} should throw`,
+      );
+    }
+  });
+
+  it('setter throws on non-https image URL', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    assert.throws(() => {
+      bp.upcomingPassInformation = [
+        baseEntry({
+          images: {
+            headerImage: {
+              URLs: [
+                {
+                  URL: 'http://cdn.example/header.png', // http, not https
+                  SHA256,
+                },
+              ],
+            },
+          },
+        }),
+      ];
+    }, /URL must use https/);
+  });
+
+  it('setter throws on malformed image URL', () => {
     const bp = new PassBase({ eventTicket: {} });
     bp.preferredStyleSchemes = ['posterEventTicket'];
     assert.throws(() => {
@@ -176,7 +203,7 @@ describe('upcomingPassInformation', () => {
     }); // `new URL` throws TypeError
   });
 
-  it('throws on empty image URLs array', () => {
+  it('setter throws on empty image URLs array', () => {
     const bp = new PassBase({ eventTicket: {} });
     bp.preferredStyleSchemes = ['posterEventTicket'];
     assert.throws(() => {
@@ -189,6 +216,77 @@ describe('upcomingPassInformation', () => {
       ];
     }, /images\.headerImage\.URLs must be a non-empty array/);
   });
+
+  it('setter does NOT check style/scheme (that runs at pass-build time)', () => {
+    // Hydrate from a plain object with `upcomingPassInformation` BEFORE
+    // `preferredStyleSchemes` in key order — the old order-dependent
+    // validator would throw here. Must not.
+    const bp = new PassBase();
+    assert.doesNotThrow(() => {
+      bp.upcomingPassInformation = [baseEntry()];
+    });
+    // Same thing on a non-eventTicket pass — setter accepts.
+    const sc = new PassBase({ storeCard: {} });
+    assert.doesNotThrow(() => {
+      sc.upcomingPassInformation = [baseEntry()];
+    });
+  });
+
+  // ─── Cross-field context (pass-build-time) ────────────────────────────
+
+  it('context assertion throws when style is not eventTicket', () => {
+    const bp = new PassBase({ storeCard: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    bp.upcomingPassInformation = [baseEntry()];
+    assert.throws(
+      () => assertUpcomingPassInformationContext(bp.toJSON()),
+      /requires style "eventTicket"/,
+    );
+  });
+
+  it('context assertion throws when scheme misses posterEventTicket', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['eventTicket'];
+    bp.upcomingPassInformation = [baseEntry()];
+    assert.throws(
+      () => assertUpcomingPassInformationContext(bp.toJSON()),
+      /preferredStyleSchemes to include "posterEventTicket"/,
+    );
+  });
+
+  it('context assertion throws when scheme is unset', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.upcomingPassInformation = [baseEntry()];
+    assert.throws(
+      () => assertUpcomingPassInformationContext(bp.toJSON()),
+      /preferredStyleSchemes to include "posterEventTicket"/,
+    );
+  });
+
+  it('context assertion no-ops when upcomingPassInformation is unset', () => {
+    const bp = new PassBase({ storeCard: {} });
+    assert.doesNotThrow(() =>
+      assertUpcomingPassInformationContext(bp.toJSON()),
+    );
+  });
+
+  it('context assertion accepts a well-formed pass regardless of key order', () => {
+    // Emulate PassBase constructor hydrating from a plain object whose
+    // key order puts `upcomingPassInformation` first. With the new
+    // architecture, construction succeeds and the context check still
+    // sees the final state when it runs.
+    const bp = new PassBase({
+      upcomingPassInformation: [baseEntry()],
+      preferredStyleSchemes: ['posterEventTicket'],
+      eventTicket: {},
+    });
+    assert.equal(bp.upcomingPassInformation?.length, 1);
+    assert.doesNotThrow(() =>
+      assertUpcomingPassInformationContext(bp.toJSON()),
+    );
+  });
+
+  // ─── Misc ────────────────────────────────────────────────────────────
 
   it('clears via undefined', () => {
     const bp = new PassBase({ eventTicket: {} });

--- a/__tests__/upcoming-pass-information.ts
+++ b/__tests__/upcoming-pass-information.ts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2017-2026 Konstantin Vyatkin <tino@vtkn.io>
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PassBase } from '../dist/lib/base-pass.js';
+import type { UpcomingPassInformationEntry } from '../dist/lib/upcoming-pass-information.js';
+
+// Valid 64-char lowercase-hex digest used across tests.
+const SHA256 = 'a'.repeat(
+  64,
+) as UpcomingPassInformationEntry['images'] extends object ? string : string;
+
+function baseEntry(
+  overrides: Partial<UpcomingPassInformationEntry> = {},
+): UpcomingPassInformationEntry {
+  return {
+    identifier: 'evt-1',
+    name: 'Opening Night',
+    type: 'event',
+    ...overrides,
+  };
+}
+
+describe('upcomingPassInformation', () => {
+  it('valid entry round-trips, dates inside dateInformation are normalized', () => {
+    const eventDate = new Date(Date.UTC(2026, 5, 1, 19, 0, 0));
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    bp.upcomingPassInformation = [
+      baseEntry({
+        dateInformation: {
+          date: eventDate,
+          timeZone: 'America/New_York',
+        },
+        images: {
+          headerImage: {
+            URLs: [
+              {
+                URL: 'https://cdn.example/header@2x.png',
+                SHA256,
+                scale: 2,
+                size: 1000,
+              },
+            ],
+          },
+        },
+      }),
+    ];
+    const json = JSON.parse(JSON.stringify(bp));
+    assert.equal(json.upcomingPassInformation.length, 1);
+    const entry = json.upcomingPassInformation[0];
+    assert.equal(entry.identifier, 'evt-1');
+    assert.equal(entry.name, 'Opening Night');
+    assert.equal(entry.type, 'event');
+    // Date normalized by normalizeDatesDeep at toJSON time.
+    assert.match(
+      entry.dateInformation.date,
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?(?:[+-]\d{2}:\d{2}|Z)$/,
+    );
+    assert.equal(entry.images.headerImage.URLs[0].SHA256, SHA256);
+  });
+
+  it('throws when pass style is not eventTicket', () => {
+    const bp = new PassBase({ storeCard: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    assert.throws(() => {
+      bp.upcomingPassInformation = [baseEntry()];
+    }, /requires style "eventTicket"/);
+  });
+
+  it('throws when preferredStyleSchemes is missing posterEventTicket', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['eventTicket'];
+    assert.throws(() => {
+      bp.upcomingPassInformation = [baseEntry()];
+    }, /preferredStyleSchemes to include "posterEventTicket"/);
+  });
+
+  it('throws when preferredStyleSchemes is unset', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    assert.throws(() => {
+      bp.upcomingPassInformation = [baseEntry()];
+    }, /preferredStyleSchemes to include "posterEventTicket"/);
+  });
+
+  it('throws when identifier is empty', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    assert.throws(() => {
+      bp.upcomingPassInformation = [baseEntry({ identifier: '' })];
+    }, /\.identifier must be a non-empty string/);
+  });
+
+  it('throws when name is missing', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    assert.throws(() => {
+      bp.upcomingPassInformation = [
+        baseEntry({
+          name: undefined as unknown as string,
+        }),
+      ];
+    }, /\.name must be a non-empty string/);
+  });
+
+  it('throws when type is not "event"', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    assert.throws(() => {
+      bp.upcomingPassInformation = [
+        baseEntry({
+          type: 'session' as unknown as 'event',
+        }),
+      ];
+    }, /\.type must be "event"/);
+  });
+
+  it('throws on bad SHA256', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    assert.throws(() => {
+      bp.upcomingPassInformation = [
+        baseEntry({
+          images: {
+            headerImage: {
+              URLs: [
+                {
+                  URL: 'https://cdn.example/header.png',
+                  SHA256: 'a'.repeat(63), // 63 chars = invalid
+                },
+              ],
+            },
+          },
+        }),
+      ];
+    }, /SHA256 must be a 64-char hex string/);
+  });
+
+  it('throws on oversize image (> 2 MiB)', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    assert.throws(() => {
+      bp.upcomingPassInformation = [
+        baseEntry({
+          images: {
+            headerImage: {
+              URLs: [
+                {
+                  URL: 'https://cdn.example/header.png',
+                  SHA256,
+                  size: 2 * 1024 * 1024 + 1,
+                },
+              ],
+            },
+          },
+        }),
+      ];
+    }, /size exceeds 2 MiB/);
+  });
+
+  it('throws on malformed image URL', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    assert.throws(() => {
+      bp.upcomingPassInformation = [
+        baseEntry({
+          images: {
+            headerImage: {
+              URLs: [{ URL: 'not a url', SHA256 }],
+            },
+          },
+        }),
+      ];
+    }); // `new URL` throws TypeError
+  });
+
+  it('throws on empty image URLs array', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    assert.throws(() => {
+      bp.upcomingPassInformation = [
+        baseEntry({
+          images: {
+            headerImage: { URLs: [] },
+          },
+        }),
+      ];
+    }, /images\.headerImage\.URLs must be a non-empty array/);
+  });
+
+  it('clears via undefined', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    bp.preferredStyleSchemes = ['posterEventTicket'];
+    bp.upcomingPassInformation = [baseEntry()];
+    assert.equal(bp.upcomingPassInformation?.length, 1);
+    bp.upcomingPassInformation = undefined;
+    assert.equal(bp.upcomingPassInformation, undefined);
+    const json = JSON.parse(JSON.stringify(bp));
+    assert.equal(json.upcomingPassInformation, undefined);
+  });
+});

--- a/docs/passkit-generator-gap-analysis.md
+++ b/docs/passkit-generator-gap-analysis.md
@@ -1,5 +1,14 @@
 # Gap analysis: `@walletpass/pass-js` vs. `passkit-generator`
 
+> **📌 Historical baseline (pre-PR #664).** This document describes the
+> gap between pass-js (7.0.1) and passkit-generator v3.5.7 **as of
+> 2026-05-10, before any implementation work landed**. P0, P1, and P2
+> (iOS 18 event-ticket keys, iOS 26 enhanced boarding-pass keys, typed
+> `SemanticTags`, and `upcomingPassInformation`) are **implemented in
+> this PR** — see the PR description for the current state. The
+> matrix and priority plan below are preserved as the rationale for
+> the change; do not use them to assess current coverage.
+
 **Prepared:** 2026-05-10 · **Compared against:** `passkit-generator` v3.5.7
 (`c31332b`, released 2025-12-25) · **Scope:** Apple Wallet pass-generation
 feature coverage only. Build/runtime/crypto differences are noted but are

--- a/docs/passkit-generator-gap-analysis.md
+++ b/docs/passkit-generator-gap-analysis.md
@@ -1,0 +1,480 @@
+# Gap analysis: `@walletpass/pass-js` vs. `passkit-generator`
+
+**Prepared:** 2026-05-10 · **Compared against:** `passkit-generator` v3.5.7
+(`c31332b`, released 2025-12-25) · **Scope:** Apple Wallet pass-generation
+feature coverage only. Build/runtime/crypto differences are noted but are
+not the focus.
+
+## 1. Executive summary
+
+`pass-js` has a tighter, more modern runtime core (native `node:crypto`
+PKCS#7 via `pkijs` instead of `node-forge`, in-repo ZIP reader/writer
+instead of `yauzl`+`do-not-zip`, full ESM, PNG dimension validation,
+APN push via `http2`, WWDR cert rotation warnings). `passkit-generator`
+has broader **schema coverage** — particularly for iOS 18 event ticket
+extensions, iOS 26 enhanced boarding passes, and the new
+`upcomingPassInformation` structure — and exposes a few packaging
+primitives (`.pkpasses` multi-pass bundles, `getAsRaw()` / `getAsStream()`
+output modes, `from()` clone) that `pass-js` lacks.
+
+The largest functional gaps, in decreasing priority:
+
+1. **iOS 18 event-ticket layout** top-level keys (Event Guide URLs,
+   color/styling flags, auxiliary app identifiers, `additionalInfoFields`,
+   `eventLogoText`).
+2. **iOS 26 enhanced/semantic boarding pass** top-level keys (flight
+   entertainment, baggage, lounge, service URLs + transit provider
+   contact fields).
+3. **iOS 26 `upcomingPassInformation`** (poster event tickets, chained
+   upcoming events with remote images + `dateInformation`).
+4. **Semantic-tag schema drift** — `pass-js` accepts *any* object under
+   `semantics` without type-level hints for the ~35 iOS 18 and ~20
+   iOS 26 additions (admissionLevel, eventStartDateInfo, boardingZone,
+   passengerCapabilities, etc.).
+5. **Personalization** (`personalization.json` + personalization logo,
+   for NFC reward cards) — not implemented at all.
+6. **Packaging primitives** — `.pkpasses` multi-pass bundle, raw-files
+   output, stream output, clone-from-pass.
+7. **Validation depth** — global field-key uniqueness, `preferredStyleSchemes`/
+   pass-type cross-validation, transitType-required-on-close for
+   `boardingPass`, NFC allowed on non-storeCard styles.
+
+`pass-js` strengths that `passkit-generator` does **not** have, and
+which should be preserved while closing the gaps:
+
+- No `node-forge` dependency (CVE-prone historically); signature chain
+  is `pkijs` + `node:crypto`.
+- Bundled WWDR G4 with `process.emitWarning` 90 days before expiry.
+- Own ZIP reader/writer (works with Lambda / Cloudflare Workers without
+  native modules).
+- PNG dimension validation per image type and density.
+- UTF-16 LE `pass.strings` writer/reader with BOM (Apple-spec compliant;
+  `passkit-generator` writes UTF-8 which Wallet tolerates but doesn't
+  match the doc).
+- APN push updates via HTTP/2.
+
+---
+
+## 2. Side-by-side feature matrix
+
+Legend: ✅ present · ⚠️ partial · ❌ missing
+
+### 2.1 Top-level `pass.json` keys
+
+| Key | Spec origin | `pass-js` | `passkit-generator` |
+|---|---|---|---|
+| `formatVersion`, `description`, `organizationName`, `passTypeIdentifier`, `teamIdentifier`, `serialNumber` | base | ✅ | ✅ |
+| `sharingProhibited` | iOS 11 | ✅ | ✅ |
+| `appLaunchURL`, `associatedStoreIdentifiers` | base | ✅ | ✅ |
+| `userInfo` | base | ⚠️ passes through in `toJSON`, no setter | ✅ (validated) |
+| `groupingIdentifier` | base | ✅ | ✅ |
+| `suppressStripShine`, `logoText` | base | ✅ | ✅ |
+| `maxDistance`, `beacons`, `locations` | base | ✅ | ✅ |
+| `relevantDate` (deprecated iOS 18) | base | ✅ | ✅ |
+| `relevantDates` (iOS 18) | new | ✅ | ✅ |
+| `expirationDate`, `voided` | base | ✅ | ✅ |
+| `barcodes` / `barcode` (deprecated) | base | ✅ (`barcodes`) / ⚠️ keeps `barcode` in typings but no setter | ✅ (auto-fill helper from string) |
+| `backgroundColor`, `foregroundColor`, `labelColor` | base | ✅ (rich `PassColor` class, accepts rgb()/hex/named/tuple) | ✅ (hex string only) |
+| `stripColor` | undocumented | ✅ | ✅ |
+| `nfc` | base (storeCard) | ⚠️ restricted to `storeCard` only | ✅ (any style) |
+| `semantics` | base + iOS 18 + iOS 26 | ⚠️ passthrough, no type safety, no validation | ✅ full Joi schema (see §2.4) |
+| `webServiceURL` + `authenticationToken` | base | ✅ | ✅ |
+| `preferredStyleSchemes` | iOS 18 / 26 | ⚠️ only `'posterEventTicket' \| 'eventTicket'` (missing `'boardingPass' \| 'semanticBoardingPass'`) | ✅ all four values |
+| **Event Guide URLs (iOS 18, posterEventTicket)** | | | |
+| `bagPolicyURL`, `orderFoodURL`, `parkingInformationURL`, `directionsInformationURL`, `purchaseParkingURL`, `merchandiseURL`, `transitInformationURL`, `accessibilityURL`, `addOnURL`, `contactVenueEmail`, `contactVenuePhoneNumber`, `contactVenueWebsite`, `transferURL`, `sellURL` | iOS 18 | ❌ all missing | ✅ all present |
+| `suppressHeaderDarkening` | iOS 18 | ❌ | ✅ |
+| `footerBackgroundColor` | iOS 18 | ❌ | ✅ |
+| `useAutomaticColors` | iOS 18 | ❌ | ✅ |
+| `auxiliaryStoreIdentifiers` | iOS 18 | ❌ | ✅ |
+| `eventLogoText` | iOS 18.1 | ❌ | ✅ |
+| `upcomingPassInformation` | iOS 26 | ❌ | ✅ |
+| **Enhanced/Semantic Boarding Pass URLs (iOS 26)** | | | |
+| `changeSeatURL`, `entertainmentURL`, `purchaseAdditionalBaggageURL`, `purchaseLoungeAccessURL`, `purchaseWifiURL`, `upgradeURL`, `managementURL`, `registerServiceAnimalURL`, `reportLostBagURL`, `requestWheelchairURL`, `transitProviderEmail`, `transitProviderPhoneNumber`, `transitProviderWebsiteURL` | iOS 26 | ❌ all missing | ✅ all present |
+
+### 2.2 Pass-structure fields (per style)
+
+| Field | `pass-js` | `passkit-generator` |
+|---|---|---|
+| `headerFields`, `primaryFields`, `secondaryFields`, `auxiliaryFields`, `backFields` | ✅ (`FieldsMap` helper) | ✅ (`FieldsArray` helper) |
+| `transitType` (boardingPass) | ✅ (ref error if accessed on non-boardingPass) | ✅ (validated on close) |
+| `auxiliaryFields.row` (0 \| 1, eventTicket only) | ⚠️ allowed but not restricted to eventTicket | ✅ restricted via `PassFieldContentWithRow` |
+| `additionalInfoFields` (eventTicket, iOS 18) | ❌ | ✅ |
+| Global key-uniqueness across all field groups | ❌ (each `FieldsMap` is independent) | ✅ (`sharedKeysPool`) |
+| Sets pass style resets previous style's fields | ⚠️ `style` setter deletes other styles but keeps current structure | ✅ explicit reset |
+
+### 2.3 `PassFieldContent` (single field) keys
+
+| Key | `pass-js` | `passkit-generator` |
+|---|---|---|
+| `key`, `value`, `label` | ✅ | ✅ |
+| `attributedValue` | ✅ (typed `string \| number`) | ✅ (typed `string \| number \| Date`) |
+| `changeMessage` | ✅ | ✅ |
+| `dataDetectorTypes` | ✅ | ✅ |
+| `textAlignment` | ✅ | ✅ |
+| `dateStyle`, `timeStyle`, `ignoresTimeZone`, `isRelative` | ✅ | ✅ |
+| `numberStyle`, `currencyCode` | ✅ | ✅ |
+| `semantics` (per-field) | ✅ (passthrough) | ✅ (Joi-validated) |
+
+### 2.4 Semantic tags (iOS 18 / iOS 26 additions)
+
+`passkit-generator` ships a 960-line Joi schema
+(`src/schemas/Semantics.ts`) covering everything Apple has published.
+`pass-js` treats `semantics` as an opaque `SemanticTagObject`; only the
+Date-to-W3C normalization runs, so invalid payloads reach Wallet and are
+silently discarded.
+
+Tags **only** in `passkit-generator`'s typed surface:
+
+**iOS 18 (event ticket, new layout):**
+`admissionLevel`, `admissionLevelAbbreviation`, `albumIDs`, `airplay`,
+`attendeeName`, `additionalTicketAttributes`, `entranceDescription`,
+`eventLiveMessage`, `eventStartDateInfo` (with `EventDateInfo.unannounced`/
+`undetermined` in iOS 18.1), `playlistIDs`, `tailgatingAllowed`,
+`venueGatesOpenDate`, `venueParkingLotsOpenDate`, `venueBoxOfficeOpenDate`,
+`venueDoorsOpenDate`, `venueFanZoneOpenDate`, `venueOpenDate`,
+`venueCloseDate`, `venueRegionName`, `venueEntranceGate`,
+`venueEntranceDoor`, `venueEntrancePortal`, `seatAisle`, `seatLevel`,
+`seatSectionColor`.
+
+**iOS 26 (enhanced boarding pass):**
+`boardingZone`, `departureCityName`, `departureLocationSecurityPrograms`,
+`departureLocationTimeZone`, `destinationCityName`,
+`destinationLocationSecurityPrograms`, `destinationLocationTimeZone`,
+`internationalDocumentsAreVerified`,
+`internationalDocumentsVerifiedDeclarationName`, `loungePlaceIDs`,
+`membershipProgramStatus`, `passengerAirlineSSRs`,
+`passengerCapabilities`, `passengerEligibleSecurityPrograms`,
+`passengerInformationSSRs`, `passengerServiceSSRs`, `ticketFareClass`.
+
+Because `pass-js`'s `SemanticTags = SemanticTagObject` is typed as
+`{ [key: string]: SemanticTagValue }`, users can still write any of these
+today — they're just undiscoverable, untyped, and uncaught when
+misspelled.
+
+### 2.5 Secondary structures
+
+| Structure | `pass-js` | `passkit-generator` |
+|---|---|---|
+| `Beacon` | ✅ minimal (proximityUUID) | ✅ + `major`/`minor` 0–65535 validation |
+| `Location` | ✅ | ✅ |
+| `Barcode` | ✅ (messageEncoding **required**) | ✅ (messageEncoding defaults to `iso-8859-1`) |
+| `NFC` | ✅ (with `setPublicKey(pem)` helper + P-256 enforcement) | ✅ (plain validation only) |
+| `Personalize` (`personalization.json`) | ❌ | ✅ |
+| `SemanticTagType.CurrencyAmount`, `Location`, `PersonNameComponents`, `Seat`, `WifiNetwork`, `EventDateInfo` | ❌ (untyped passthrough) | ✅ |
+
+### 2.6 Packaging / export
+
+| Capability | `pass-js` | `passkit-generator` |
+|---|---|---|
+| `.pkpass` Buffer output | ✅ `pass.asBuffer()` | ✅ `pass.getAsBuffer()` |
+| `.pkpass` stream output | ❌ | ✅ `pass.getAsStream()` |
+| `.pkpass` raw (path → buffer) output | ❌ | ✅ `pass.getAsRaw()` |
+| `.pkpasses` multi-pass bundle (zip-of-pkpass, MIME `application/vnd.apple.pkpasses`) | ❌ | ✅ `PKPass.pack(...passes)` |
+| Clone pass → pass with prop overrides | ⚠️ via `Template.fromBuffer(await src.asBuffer())` | ✅ `PKPass.from(src, overrides)` |
+| Load template from folder | ✅ `Template.load(path)` | ✅ (via `from()` with `{ model, certificates }`) |
+| Reconstruct template from buffer (e.g. S3-fetched pkpass) | ✅ `Template.fromBuffer(buf)` | ⚠️ `PKPass.from(PKPass)` only clones, not raw zip |
+| Localization from folder, `.lproj/pass.strings` | ✅ (UTF-16 LE + BOM) | ✅ (UTF-8) |
+| Localized images (`<lang>.lproj/icon@2x.png`) | ✅ (per-density, per-lang) | ✅ |
+
+### 2.7 Signing & crypto
+
+| Capability | `pass-js` | `passkit-generator` |
+|---|---|---|
+| PKCS#7 detached SignedData over `manifest.json` | ✅ `pkijs` + `node:crypto` | ✅ `node-forge` |
+| WWDR bundled | ✅ G4, PEM inlined with rotation warning hooked into `process.emitWarning` at 90-day window | ❌ — caller must supply every time |
+| WWDR override for dev | ✅ `APPLE_WWDR_CERT_PEM` env var | n/a |
+| Encrypted private key handling | ✅ via `createPrivateKey({ passphrase })` | ✅ via forge's `decryptRsaPrivateKey` |
+| SHA-1 manifest hash (per Apple spec) | ✅ | ✅ |
+| APN push notification | ✅ `http2` native | ❌ |
+| Browser/Cloudflare Workers friendly | ✅ (bundle-clean, no `__dirname`) | ⚠️ — `PKPass` pulls `node:stream` + `node:path`; `Joi.binary` has fallback |
+
+### 2.8 Image handling
+
+| Capability | `pass-js` | `passkit-generator` |
+|---|---|---|
+| PNG signature check | ✅ | ❌ (trusts caller) |
+| PNG dimension validation per image type + density | ✅ | ❌ |
+| Densities: `1x`/`2x`/`3x` | ✅ | ✅ |
+| Localized images per lang | ✅ | ✅ |
+| Personalization logo | ❌ | ✅ (auto-strip if not used) |
+
+---
+
+## 3. Priority plan
+
+### P0 — iOS 18 event-ticket parity (ship within current minor cycle)
+
+The largest user-visible surface. Everything here is already live in the
+field (iOS 18 GA'd 2024-09-16) and Wallet silently ignores unknown keys,
+so "it still works" masks the gap — users building event tickets with
+`pass-js` cannot opt into the new layout at all.
+
+1. **Top-level event-ticket URL keys.** Add typed setters on
+   `PassBase` (or a new `EventTicketKeys` mixin) for
+   `bagPolicyURL`, `orderFoodURL`, `parkingInformationURL`,
+   `directionsInformationURL`, `purchaseParkingURL`, `merchandiseURL`,
+   `transitInformationURL`, `accessibilityURL`, `addOnURL`,
+   `contactVenueEmail`, `contactVenuePhoneNumber`, `contactVenueWebsite`,
+   `transferURL`, `sellURL`.
+   *Cost:* ~14 setter pairs following the existing pattern in
+   `src/lib/base-pass.ts:160-250`. One test fixture asserting they
+   round-trip into `pass.json`.
+
+2. **Event-ticket styling flags.** `suppressHeaderDarkening` (bool),
+   `footerBackgroundColor` (PassColor), `useAutomaticColors` (bool),
+   `auxiliaryStoreIdentifiers` (number[]), `eventLogoText` (string).
+   *Cost:* 5 setters, 1 test.
+
+3. **`additionalInfoFields`** on event-ticket pass structure.
+   Extend `src/interfaces.ts:339` `PassCommonStructure` with an optional
+   `additionalInfoFields?: Field[] | FieldsMap`, extend
+   `src/lib/pass-structure.ts` the same way the other field groups are
+   wired (but only instantiate if `style === 'eventTicket'`). Add to
+   `STRUCTURE_FIELDS` in `src/constants.ts:237`.
+   *Cost:* ~30 LOC + test.
+
+4. **Extend `preferredStyleSchemes`** union to include
+   `'boardingPass' | 'semanticBoardingPass'` (iOS 26; cheap to add
+   now). `src/interfaces.ts:433`.
+
+5. **Semantic-tag type hints.** Replace the
+   `SemanticTags = SemanticTagObject` passthrough with a discriminated,
+   mostly-optional interface covering the ~35 iOS 18 fields listed in
+   §2.4. Keep the fallback to the generic record so users can write
+   future fields before we type them. *Cost:* 1 interface file, no
+   runtime change.
+
+**Total P0 effort:** ~1.5 engineer-days including tests and CHANGELOG.
+No breaking changes — pure additive `feat:` commits.
+
+### P1 — iOS 26 boarding pass parity
+
+Ships with iOS 26 (GA'd autumn 2025 per Apple's pass spec); the
+semantic boarding pass template is opt-in via `preferredStyleSchemes`
+so absent keys silently no-op, but anyone targeting airlines/rail in
+2026+ will want these.
+
+1. **Transit provider / service URL keys.** Add setters for
+   `changeSeatURL`, `entertainmentURL`, `purchaseAdditionalBaggageURL`,
+   `purchaseLoungeAccessURL`, `purchaseWifiURL`, `upgradeURL`,
+   `managementURL`, `registerServiceAnimalURL`, `reportLostBagURL`,
+   `requestWheelchairURL`, `transitProviderEmail`,
+   `transitProviderPhoneNumber`, `transitProviderWebsiteURL`.
+   Same pattern as P0 #1. *Cost:* 13 setters, 1 test.
+
+2. **iOS 26 semantic tags.** Add to the typed interface from P0 #5:
+   `boardingZone`, `passengerCapabilities` (enum array),
+   `passengerEligibleSecurityPrograms` (enum array),
+   `departureLocationSecurityPrograms`,
+   `destinationLocationSecurityPrograms`, `ticketFareClass`,
+   `membershipProgramStatus`, `loungePlaceIDs`, `departureCityName`,
+   `destinationCityName`, `departureLocationTimeZone`,
+   `destinationLocationTimeZone`,
+   `internationalDocumentsAreVerified`,
+   `internationalDocumentsVerifiedDeclarationName`,
+   `passengerAirlineSSRs`, `passengerInformationSSRs`,
+   `passengerServiceSSRs`. *Cost:* interface extension only.
+
+**Total P1 effort:** ~1 day.
+
+### P2 — `upcomingPassInformation` (iOS 26)
+
+This is the largest new structure in the 2025-2026 Wallet cycle — it
+lets a pass declare future related events (multi-day concerts, season
+passes, chained flights) with remote imagery fetched over HTTPS
+against a SHA256 allowlist.
+
+Full shape lives at
+`/tmp/passkit-generator/src/schemas/UpcomingPassInformation.ts:190-261`
+and pulls in nested `Image` (`URLs: [{ SHA256, URL, scale, size }]`,
+`reuseExisting`), `Images` (headerImage, venueMap), `URLs` (14 event
+guide URLs mirroring P0 #1), `DateInformation` (date, `timeZone`,
+`ignoreTimeComponents`, `isAllDay`, `isUnannounced`, `isUndetermined`),
+plus the required `identifier`/`name`/`type: "event"` contract.
+
+*Cost:* ~200 LOC schema types + 1 setter that cross-validates
+against `preferredStyleSchemes.includes('posterEventTicket')` + 1
+pass fixture + test. **1–2 engineer-days.**
+
+Validation to mirror from `passkit-generator`:
+
+- `type` must be `'event'`
+- `identifier` + `name` required
+- Image `SHA256` required; `size` ≤ 2 MiB
+- Only valid when `style === 'eventTicket'` and
+  `preferredStyleSchemes` includes `'posterEventTicket'`
+
+### P3 — Personalization (`personalization.json` + logo)
+
+Apple's PassKit Personalization flow for NFC reward cards. Rarely
+used but blocks anyone migrating an existing passkit-generator
+integration that depends on it.
+
+Files involved in a personalized pass:
+
+- `personalization.json` with `description`, `requiredPersonalizationFields`
+  (`PKPassPersonalizationFieldName` / `…PostalCode` / `…EmailAddress` /
+  `…PhoneNumber`), optional `termsAndConditions`.
+- `personalizationLogo.png` + `@2x` / `@3x`.
+
+Requirements for shipping (per Apple doc + passkit-generator's behavior):
+the bundle needs BOTH `nfc` set AND a personalization logo AND
+`personalization.json` — if any is absent, strip silently. Match that
+defensive behavior.
+
+*Cost:* new `src/lib/personalization.ts` (~80 LOC), update
+`src/lib/images.ts` to accept `personalizationLogo` as an image type,
+update `src/pass.ts:asBuffer` to strip conditionally. Test with a
+self-signed personalized storeCard round-trip. **~1 day.**
+
+### P4 — Packaging primitives
+
+1. **`.pkpasses` bundle** (`application/vnd.apple.pkpasses`) — a zip of
+   `.pkpass` files. `passkit-generator` exposes `PKPass.pack(...passes)`.
+   Useful for airline boarding-pass batches, family tickets, etc.
+   *Implementation:* re-use `src/lib/zip.ts` `writeZip`, outer filename
+   pattern `packed-pass-N.pkpass`, return `Buffer`. Add a static
+   `Pass.pack(...passes)` on the `Pass` class. *Cost:* ~40 LOC + test.
+
+2. **`asStream()`** — wrap the Buffer in a `Readable.from()` for
+   streaming upload to S3 / CloudFront. *Cost:* 5 LOC + test.
+
+3. **`asRaw()`** — return `{ [filePath]: Buffer }`, letting the caller
+   choose their own zipper. Useful for serverless environments that
+   already do streaming compression. *Cost:* ~20 LOC (would refactor
+   `asBuffer` to derive from it) + test.
+
+**Total P4 effort:** ~half day.
+
+### P5 — Validation depth
+
+These are safety nets that catch mistakes on the developer's side.
+Not strictly necessary (Wallet tolerates unknown keys and duplicate
+keys silently), but prevent subtle bugs.
+
+1. **Global field-key uniqueness** across header/primary/secondary/aux/back.
+   Mirror passkit-generator's `sharedKeysPool` pattern in
+   `src/lib/pass-structure.ts`. Throw or warn on collision. *Cost:* ~30 LOC + test.
+
+2. **Close-time validation** — when building the pass:
+   - `boardingPass` without `transitType` → throw (currently no check).
+   - `upcomingPassInformation` without `'posterEventTicket'` in
+     `preferredStyleSchemes` → throw.
+   - `useAutomaticColors` + explicit `foregroundColor`/`labelColor` →
+     warn (Apple ignores the explicit ones).
+3. **Allow NFC on any pass style** — Apple spec allows it on any style,
+   not just `storeCard`. `src/lib/pass-structure.ts:131-137` currently
+   throws for non-storeCard. Relax the guard.
+
+**Total P5 effort:** ~1 day.
+
+### P6 — Deprecations & nice-to-haves
+
+- Keep `relevantDate` singular setter but emit a `process.emitWarning`
+  on first use, pointing at `relevantDates`.
+- Add `EventDateInfo.unannounced` / `undetermined` typings once
+  `eventStartDateInfo` is exposed.
+- Barcode auto-fill helper: `pass.setBarcodes('payload')` expands into
+  four `BarcodeFormat` fallbacks (QR, PDF417, Aztec, Code128), matching
+  `passkit-generator`'s convenience signature.
+- Accept PEM for NFC `encryptionPublicKey` in the top-level setter too
+  (pass-js already has `NFCField.setPublicKey`, but not at the pass
+  level).
+
+---
+
+## 4. Recommended release cadence
+
+| Release | Contents | Breaking? |
+|---|---|---|
+| 7.1.0 | P0 (iOS 18 event ticket parity) | no |
+| 7.2.0 | P1 (iOS 26 boarding pass URLs + semantic tags) | no |
+| 7.3.0 | P2 (`upcomingPassInformation`) | no |
+| 7.4.0 | P4 (`pack`, `asStream`, `asRaw`) + P5 (validation) | P5 #3 could be an edge case — current throws become silent passes; probably non-breaking since nobody was hitting it on purpose |
+| 7.5.0 | P3 (personalization) | no |
+| 7.x.0 | P6 (polish) | no |
+
+Everything is additive — no `feat!:` commits required. Only P5 #3
+(NFC on non-storeCard) crosses into silently-now-accepts territory, and
+that's a capability expansion rather than a removal.
+
+---
+
+## 5. Things `pass-js` does better — preserve when closing gaps
+
+Before touching the P0–P6 work, keep these advantages intact:
+
+1. **`PassColor` accepts hex, `rgb(...)`, named colors, and
+   `[r, g, b]` tuples.** Don't shrink to plain hex strings like
+   `passkit-generator` does.
+2. **PNG dimension validation per image type and density** catches
+   sizing bugs at `template.load()` time, before Wallet rejects the
+   pass on device. Keep the check in the new
+   `personalizationLogo` path too (P3).
+3. **APN push via HTTP/2** — no plans to rip out. `Template.pushUpdates`
+   is a `pass-js` exclusive; document it more loudly.
+4. **Native WWDR rotation warning** — keep `WALLETPASS_WWDR_EXPIRING`/
+   `…_EXPIRED`. If we rotate to G5, bump the constant name in
+   `src/lib/sign-manifest.ts:38` but keep the warning wiring.
+5. **UTF-16 LE `pass.strings` with BOM** — correct per Apple's docs.
+   `passkit-generator` writes UTF-8 which Wallet tolerates but the
+   spec says otherwise.
+6. **Own zip reader/writer in `src/lib/zip.ts`** — removed `yauzl`
+   and `do-not-zip` deps, works in Lambda/Workers. Any new packaging
+   primitives (P4) should layer on this, not pull in a new dependency.
+7. **No `node-forge` dependency** — last rotated out in v7; don't
+   regress. `node-forge` has had a steady CVE cadence (most recently
+   CVE-2025-12816 hit passkit-generator's 3.5.6).
+
+---
+
+## 6. Appendix: line-level references
+
+passkit-generator source examined (all paths relative to the cloned
+repo at `/tmp/passkit-generator`):
+
+- `src/PKPass.ts:32-1212` — main class, setters, getters, manifest
+  assembly, close-time validation.
+- `src/schemas/index.ts:105-574` — `PassProps` interface; single source
+  of truth for iOS 18 / iOS 26 top-level key inventory.
+- `src/schemas/index.ts:599-1037` — Joi validators for same.
+- `src/schemas/Semantics.ts:1-962` — semantic-tag schema.
+- `src/schemas/SemanticTagType.ts:1-203` — `EventDateInfo`,
+  `CurrencyAmount`, `Seat` (with iOS 18 additions `seatAisle`,
+  `seatLevel`, `seatSectionColor`), `PersonNameComponents`,
+  `WifiNetwork`, `Location`.
+- `src/schemas/PassFields.ts:1-52` — structure fields incl.
+  `additionalInfoFields`.
+- `src/schemas/PassFieldContent.ts:33-115` — field dictionary.
+- `src/schemas/UpcomingPassInformation.ts:1-261` — iOS 26 upcoming pass
+  info (the biggest single new structure).
+- `src/schemas/Personalize.ts:1-30` — personalization schema.
+- `src/schemas/NFC.ts`, `Beacon.ts`, `Location.ts`, `Barcode.ts`,
+  `Certificates.ts` — leaf validators.
+- `src/Bundle.ts:1-178` — Bundle class with `getAsBuffer`,
+  `getAsStream`, `getAsRaw`, `freezable`.
+- `src/FieldsArray.ts:1-117` — shared-keys-pool logic.
+- `src/Signature.ts:1-130` — PKCS#7 via node-forge (reference only).
+- `src/StringsUtils.ts` — UTF-8 pass.strings parser.
+
+pass-js source examined:
+
+- `src/interfaces.ts:517-525` — `ApplePass` composition (missing
+  iOS 18 / iOS 26 key mixins).
+- `src/interfaces.ts:339-362` — `PassCommonStructure` (missing
+  `additionalInfoFields`).
+- `src/lib/base-pass.ts:196-203` — `preferredStyleSchemes` setter
+  (needs union extension).
+- `src/lib/pass-structure.ts:131-137` — NFC storeCard restriction to
+  relax.
+- `src/lib/semantic-tags.ts:48-50` — `SemanticTags` passthrough
+  (needs interface).
+- `src/constants.ts:237-243` — `STRUCTURE_FIELDS` (append
+  `additionalInfoFields`).
+- `src/constants.ts:70-99` — `IMAGES` (append
+  `personalizationLogo` in P3).
+- `src/pass.ts:63-96` — `asBuffer` (wrap with `asRaw` / `asStream`
+  in P4, branch for personalization stripping in P3).
+- `src/lib/zip.ts` — reused for `.pkpasses` bundle.
+
+End of report.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -233,11 +233,49 @@ export const TOP_LEVEL_FIELDS: {
     type: 'string',
     templatable: true,
   },
+  // iOS 18 Event Ticket Keys — Event Guide URLs, contact, transfer/sell
+  bagPolicyURL: { type: 'string', templatable: true },
+  orderFoodURL: { type: 'string', templatable: true },
+  parkingInformationURL: { type: 'string', templatable: true },
+  directionsInformationURL: { type: 'string', templatable: true },
+  purchaseParkingURL: { type: 'string', templatable: true },
+  merchandiseURL: { type: 'string', templatable: true },
+  transitInformationURL: { type: 'string', templatable: true },
+  accessibilityURL: { type: 'string', templatable: true },
+  addOnURL: { type: 'string', templatable: true },
+  contactVenueEmail: { type: 'string', templatable: true },
+  contactVenuePhoneNumber: { type: 'string', templatable: true },
+  contactVenueWebsite: { type: 'string', templatable: true },
+  transferURL: { type: 'string', templatable: true },
+  sellURL: { type: 'string', templatable: true },
+  // iOS 18 Event Ticket Keys — styling + misc
+  suppressHeaderDarkening: { type: Boolean, templatable: true },
+  footerBackgroundColor: { type: 'string', templatable: true },
+  useAutomaticColors: { type: Boolean, templatable: true },
+  auxiliaryStoreIdentifiers: { type: Array, templatable: true },
+  eventLogoText: { type: 'string', templatable: true, localizable: true },
+  // iOS 26 Enhanced / Semantic Boarding Pass Keys
+  changeSeatURL: { type: 'string', templatable: true },
+  entertainmentURL: { type: 'string', templatable: true },
+  purchaseAdditionalBaggageURL: { type: 'string', templatable: true },
+  purchaseLoungeAccessURL: { type: 'string', templatable: true },
+  purchaseWifiURL: { type: 'string', templatable: true },
+  upgradeURL: { type: 'string', templatable: true },
+  managementURL: { type: 'string', templatable: true },
+  registerServiceAnimalURL: { type: 'string', templatable: true },
+  reportLostBagURL: { type: 'string', templatable: true },
+  requestWheelchairURL: { type: 'string', templatable: true },
+  transitProviderWebsiteURL: { type: 'string', templatable: true },
+  transitProviderEmail: { type: 'string', templatable: true },
+  transitProviderPhoneNumber: { type: 'string', templatable: true },
+  // iOS 26 Poster Event Ticket — upcoming chained events
+  upcomingPassInformation: { type: Array },
 };
 
 // Pass structure keys.
 // https://developer.apple.com/library/content/documentation/UserExperience/Reference/PassKit_Bundle/Chapters/LowerLevel.html#//apple_ref/doc/uid/TP40012026-CH3-SW3
 export const STRUCTURE_FIELDS: readonly (keyof PassCommonStructure)[] = [
+  'additionalInfoFields',
   'auxiliaryFields',
   'backFields',
   'headerFields',

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,27 @@ export type {
   SemanticTags,
   SemanticTagValue,
   SemanticTagObject,
+  // Semantic-tag sub-types
+  CurrencyAmount,
+  EventDateInfo,
+  PersonNameComponents,
+  Seat,
+  SemanticLocation,
+  WifiNetwork,
+  PKPassengerCapability,
+  PKTransitSecurityProgram,
+  // iOS 18 / 26 top-level key mixins
+  PassEventTicketKeys,
+  PassEnhancedBoardingPassKeys,
+  PassUpcomingKeys,
 } from './interfaces.js';
+export type {
+  DateInformation,
+  Image,
+  Images,
+  ImageURLEntry,
+  UpcomingEntrySemantics,
+  UpcomingPassInformationEntry,
+  UpcomingPassInformationType,
+  UpcomingURLs,
+} from './lib/upcoming-pass-information.js';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -47,14 +47,254 @@ export type SemanticTagValue =
   | SemanticTagObject
   | SemanticTagValue[];
 
+// ─── Semantic-tag sub-types ─────────────────────────────────────────────────
+// https://developer.apple.com/documentation/walletpasses/semantictagtype
+
+/** ISO 4217 currency amount. */
+export interface CurrencyAmount {
+  amount: string | number;
+  currencyCode: string;
+}
+
+/** Geographic coordinate, used by `departureLocation`, `venueLocation`, etc. */
+export interface SemanticLocation {
+  latitude: number;
+  longitude: number;
+}
+
+export interface PersonNameComponents {
+  givenName?: string;
+  familyName?: string;
+  middleName?: string;
+  namePrefix?: string;
+  nameSuffix?: string;
+  nickname?: string;
+  phoneticRepresentation?: string;
+}
+
+export interface WifiNetwork {
+  ssid: string;
+  password: string;
+}
+
+export interface Seat {
+  seatDescription?: string;
+  seatIdentifier?: string;
+  seatNumber?: string;
+  seatRow?: string;
+  seatSection?: string;
+  seatType?: string;
+  /** iOS 18+ */
+  seatAisle?: string;
+  /** iOS 18+ */
+  seatLevel?: string;
+  /** iOS 18+. CSS-style RGB/hex color for the section swatch. */
+  seatSectionColor?: string;
+}
+
+/**
+ * iOS 18+ alternative to the bare `eventStartDate`, with more control over
+ * time display, timezone, and TBA/TBD states (iOS 18.1).
+ */
+export interface EventDateInfo {
+  date: string | Date;
+  timeZone?: string;
+  ignoreTimeComponents?: boolean;
+  /** iOS 18.1 — renders "TBA" when the time has not been announced. */
+  unannounced?: boolean;
+  /** iOS 18.1 — renders "TBD" for undetermined start time. */
+  undetermined?: boolean;
+}
+
+// iOS 26 — transit security program enums
+export type PKTransitSecurityProgram =
+  | 'PKTransitSecurityProgramTSAPreCheck'
+  | 'PKTransitSecurityProgramTSAPreCheckTouchlessID'
+  | 'PKTransitSecurityProgramOSS'
+  | 'PKTransitSecurityProgramITI'
+  | 'PKTransitSecurityProgramITD'
+  | 'PKTransitSecurityProgramGlobalEntry'
+  | 'PKTransitSecurityProgramCLEAR';
+
+// iOS 26 — passenger capability enums
+export type PKPassengerCapability =
+  | 'PKPassengerCapabilityPreboarding'
+  | 'PKPassengerCapabilityPriorityBoarding'
+  | 'PKPassengerCapabilityCarryon'
+  | 'PKPassengerCapabilityPersonalItem';
+
 /**
  * Machine-readable metadata that Wallet uses to offer a pass and suggest
- * related actions.
+ * related actions. Covers every field Apple has documented through
+ * iOS 26.
+ *
+ * Strictly typed — assigning a key Apple hasn't documented produces a
+ * TypeScript error. To write an undocumented or not-yet-typed tag,
+ * cast through `SemanticTagObject` at the assignment site.
  *
  * @see {@link https://developer.apple.com/documentation/walletpasses/supporting-semantic-tags-in-wallet-passes}
  * @see {@link https://developer.apple.com/documentation/walletpasses/semantictags}
  */
-export type SemanticTags = SemanticTagObject;
+export interface SemanticTags {
+  // ── Pre-iOS-18 baseline ──────────────────────────────────────────────────
+  airlineCode?: string;
+  artistIDs?: string[];
+  awayTeamAbbreviation?: string;
+  awayTeamLocation?: string;
+  awayTeamName?: string;
+  balance?: CurrencyAmount;
+  boardingGroup?: string;
+  boardingSequenceNumber?: string;
+  carNumber?: string;
+  confirmationNumber?: string;
+  currentArrivalDate?: string | Date;
+  currentBoardingDate?: string | Date;
+  currentDepartureDate?: string | Date;
+  departureAirportCode?: string;
+  departureAirportName?: string;
+  departureGate?: string;
+  departureLocation?: SemanticLocation;
+  departureLocationDescription?: string;
+  departurePlatform?: string;
+  departureStationName?: string;
+  departureTerminal?: string;
+  destinationAirportCode?: string;
+  destinationAirportName?: string;
+  destinationGate?: string;
+  destinationLocation?: SemanticLocation;
+  destinationLocationDescription?: string;
+  destinationPlatform?: string;
+  destinationStationName?: string;
+  destinationTerminal?: string;
+  duration?: number;
+  eventEndDate?: string | Date;
+  eventName?: string;
+  eventStartDate?: string | Date;
+  eventType?:
+    | 'PKEventTypeGeneric'
+    | 'PKEventTypeLivePerformance'
+    | 'PKEventTypeMovie'
+    | 'PKEventTypeSports'
+    | 'PKEventTypeConference'
+    | 'PKEventTypeConvention'
+    | 'PKEventTypeWorkshop'
+    | 'PKEventTypeSocialGathering';
+  flightCode?: string;
+  flightNumber?: number;
+  genre?: string;
+  homeTeamAbbreviation?: string;
+  homeTeamLocation?: string;
+  homeTeamName?: string;
+  leagueAbbreviation?: string;
+  leagueName?: string;
+  membershipProgramName?: string;
+  membershipProgramNumber?: string;
+  originalArrivalDate?: string | Date;
+  originalBoardingDate?: string | Date;
+  originalDepartureDate?: string | Date;
+  passengerName?: PersonNameComponents;
+  performerNames?: string[];
+  priorityStatus?: string;
+  seats?: Seat[];
+  securityScreening?: string;
+  silenceRequested?: boolean;
+  sportName?: string;
+  totalPrice?: CurrencyAmount;
+  transitProvider?: string;
+  transitStatus?: string;
+  transitStatusReason?: string;
+  vehicleName?: string;
+  vehicleNumber?: string;
+  vehicleType?: string;
+  venueEntrance?: string;
+  venueLocation?: SemanticLocation;
+  venueName?: string;
+  venuePhoneNumber?: string;
+  venueRoom?: string;
+  wifiAccess?: WifiNetwork[];
+
+  // ── iOS 18 event-ticket additions ────────────────────────────────────────
+  /** iOS 18 */
+  admissionLevel?: string;
+  /** iOS 18 */
+  admissionLevelAbbreviation?: string;
+  /** iOS 18 */
+  albumIDs?: string[];
+  /** iOS 18. `true` enables AirPlay playback controls on the pass. */
+  airplay?: boolean;
+  /** iOS 18 */
+  attendeeName?: string;
+  /** iOS 18 */
+  additionalTicketAttributes?: string;
+  /** iOS 18 */
+  entranceDescription?: string;
+  /** iOS 18. Short message shown during a live activity. */
+  eventLiveMessage?: string;
+  /** iOS 18 / 18.1. Structured alternative to `eventStartDate`. */
+  eventStartDateInfo?: EventDateInfo;
+  /** iOS 18 */
+  playlistIDs?: string[];
+  /** iOS 18 */
+  tailgatingAllowed?: boolean;
+  /** iOS 18 */
+  venueGatesOpenDate?: string | Date;
+  /** iOS 18 */
+  venueParkingLotsOpenDate?: string | Date;
+  /** iOS 18 */
+  venueBoxOfficeOpenDate?: string | Date;
+  /** iOS 18 */
+  venueDoorsOpenDate?: string | Date;
+  /** iOS 18 */
+  venueFanZoneOpenDate?: string | Date;
+  /** iOS 18 */
+  venueOpenDate?: string | Date;
+  /** iOS 18 */
+  venueCloseDate?: string | Date;
+  /** iOS 18 */
+  venueRegionName?: string;
+  /** iOS 18 */
+  venueEntranceGate?: string;
+  /** iOS 18 */
+  venueEntranceDoor?: string;
+  /** iOS 18 */
+  venueEntrancePortal?: string;
+
+  // ── iOS 26 enhanced boarding pass additions ─────────────────────────────
+  /** iOS 26 */
+  boardingZone?: string;
+  /** iOS 26 */
+  departureCityName?: string;
+  /** iOS 26 */
+  destinationCityName?: string;
+  /** iOS 26 */
+  departureLocationSecurityPrograms?: PKTransitSecurityProgram[];
+  /** iOS 26 */
+  destinationLocationSecurityPrograms?: PKTransitSecurityProgram[];
+  /** iOS 26 */
+  passengerEligibleSecurityPrograms?: PKTransitSecurityProgram[];
+  /** iOS 26. IANA time zone name, e.g. `America/Chicago`. */
+  departureLocationTimeZone?: string;
+  /** iOS 26. IANA time zone name, e.g. `America/Los_Angeles`. */
+  destinationLocationTimeZone?: string;
+  /** iOS 26 */
+  internationalDocumentsAreVerified?: boolean;
+  /** iOS 26 */
+  internationalDocumentsVerifiedDeclarationName?: string;
+  /** iOS 26. MapKit Place IDs referencing lounge locations. */
+  loungePlaceIDs?: string[];
+  /** iOS 26 */
+  membershipProgramStatus?: string;
+  /** iOS 26 */
+  passengerAirlineSSRs?: string[];
+  /** iOS 26 */
+  passengerCapabilities?: PKPassengerCapability[];
+  /** iOS 26. IATA information SSRs. */
+  passengerInformationSSRs?: string[];
+  /** iOS 26. IATA service SSRs. */
+  passengerServiceSSRs?: string[];
+  /** iOS 26. Fare class badge displayed on the boarding pass. */
+  ticketFareClass?: string;
+}
 
 export type FieldDescriptor = {
   // Standard Field Dictionary Keys
@@ -362,6 +602,12 @@ export interface PassCommonStructure {
    * Fields to be on the back of the pass.
    */
   backFields?: Field[] | FieldsMap;
+  /**
+   * Event-ticket dashboard fields (iOS 18+). Only valid on `eventTicket`
+   * passes; the setter on `PassStructure` throws a ReferenceError if
+   * accessed on another style.
+   */
+  additionalInfoFields?: Field[] | FieldsMap;
 }
 
 /**
@@ -428,12 +674,18 @@ export interface PassVisualAppearanceKeys {
   /**
    * Ordered list of visual style schemes the pass opts into, in order
    * of preference. iOS 18+ renders `posterEventTicket` with richer
-   * hero imagery for event passes; older OSes silently fall back to
-   * the classic style.
+   * hero imagery for event passes; iOS 26 adds `semanticBoardingPass`
+   * for enhanced boarding-pass layouts. Older OSes silently fall back
+   * to the classic style.
    *
    * @see {@link https://developer.apple.com/documentation/walletpasses/preferredstyleschemes}
    */
-  preferredStyleSchemes?: ('posterEventTicket' | 'eventTicket')[];
+  preferredStyleSchemes?: (
+    | 'posterEventTicket'
+    | 'eventTicket'
+    | 'boardingPass'
+    | 'semanticBoardingPass'
+  )[];
 }
 
 export interface PassWebServiceKeys {
@@ -517,6 +769,106 @@ export type PassStructureFields =
   | GenericPass
   | StoreCardPass;
 
+/**
+ * iOS 18 event-ticket "Event Guide" and styling keys.
+ *
+ * All fields are optional. They apply only to `eventTicket` passes
+ * using the new poster layout (`preferredStyleSchemes` includes
+ * `'posterEventTicket'`). Older iOS versions silently ignore them.
+ */
+export interface PassEventTicketKeys {
+  /** Event Guide: URL to the bag/re-entry policy. */
+  bagPolicyURL?: string;
+  /** Event Guide: URL to order food at the venue. */
+  orderFoodURL?: string;
+  /** Event Guide: URL to parking information. */
+  parkingInformationURL?: string;
+  /** Event Guide: URL to directions to the venue. */
+  directionsInformationURL?: string;
+  /** Event Guide: URL to purchase parking. */
+  purchaseParkingURL?: string;
+  /** Event Guide: URL to purchase merchandise. */
+  merchandiseURL?: string;
+  /** Event Guide: URL to transit information. */
+  transitInformationURL?: string;
+  /** Event Guide: URL to accessibility information. */
+  accessibilityURL?: string;
+  /** Event Guide: URL to add-on experiences / upgrades. */
+  addOnURL?: string;
+  /** Event Guide: venue contact email address (plain string, not a URL). */
+  contactVenueEmail?: string;
+  /** Event Guide: venue contact phone number. */
+  contactVenuePhoneNumber?: string;
+  /** Event Guide: venue website URL. */
+  contactVenueWebsite?: string;
+  /** Menu dropdown: URL to initiate ticket transfer. */
+  transferURL?: string;
+  /** Menu dropdown: URL to resell the ticket. */
+  sellURL?: string;
+  /** Disables the automatic dark shadow behind the header in new layouts. */
+  suppressHeaderDarkening?: boolean;
+  /** Overrides the footer chin color (defaults to blurred background). */
+  footerBackgroundColor?: PassColor | string;
+  /**
+   * When `true`, Wallet derives `foregroundColor` and `labelColor` from
+   * the background image automatically; any explicit values are ignored.
+   */
+  useAutomaticColors?: boolean;
+  /**
+   * Secondary App Store identifiers related to the event ticket. Unlike
+   * `associatedStoreIdentifiers`, apps listed here cannot read the user's
+   * passes.
+   */
+  auxiliaryStoreIdentifiers?: number[];
+  /** iOS 18.1. Text shown next to the logo on `posterEventTicket` passes. */
+  eventLogoText?: string;
+}
+
+/**
+ * iOS 26 enhanced / semantic boarding-pass keys.
+ *
+ * Available when `preferredStyleSchemes` includes `'semanticBoardingPass'`.
+ * All fields are optional.
+ */
+export interface PassEnhancedBoardingPassKeys {
+  /** URL for changing the seat. */
+  changeSeatURL?: string;
+  /** URL for in-flight entertainment. */
+  entertainmentURL?: string;
+  /** URL for purchasing additional checked baggage. */
+  purchaseAdditionalBaggageURL?: string;
+  /** URL for purchasing lounge access. */
+  purchaseLoungeAccessURL?: string;
+  /** URL for purchasing in-flight Wi-Fi. */
+  purchaseWifiURL?: string;
+  /** URL for upgrading the flight. */
+  upgradeURL?: string;
+  /** URL for general ticket management. */
+  managementURL?: string;
+  /** URL for registering a service animal. */
+  registerServiceAnimalURL?: string;
+  /** URL for reporting a lost bag. */
+  reportLostBagURL?: string;
+  /** URL for requesting a wheelchair. */
+  requestWheelchairURL?: string;
+  /** Transit provider website URL. */
+  transitProviderWebsiteURL?: string;
+  /** Transit provider email address (plain string, not a URL). */
+  transitProviderEmail?: string;
+  /** Transit provider phone number. */
+  transitProviderPhoneNumber?: string;
+}
+
+/**
+ * iOS 26 poster-event-ticket key for declaring upcoming passes chained
+ * to this one. The nested shape lives in
+ * `src/lib/upcoming-pass-information.ts`; the setter on `PassBase`
+ * validates style/scheme pre-conditions and each entry's shape.
+ */
+export interface PassUpcomingKeys {
+  upcomingPassInformation?: import('./lib/upcoming-pass-information.js').UpcomingPassInformationEntry[];
+}
+
 export type ApplePass = PassStandardKeys &
   PassAssociatedAppKeys &
   PassCompanionAppKeys &
@@ -525,7 +877,10 @@ export type ApplePass = PassStandardKeys &
   PassRelevanceKeys &
   PassVisualAppearanceKeys &
   PassWebServiceKeys &
-  PassStructureFields;
+  PassStructureFields &
+  PassEventTicketKeys &
+  PassEnhancedBoardingPassKeys &
+  PassUpcomingKeys;
 
 export interface Options {
   allowHttp?: boolean;

--- a/src/lib/base-pass.ts
+++ b/src/lib/base-pass.ts
@@ -12,7 +12,7 @@ import { PassStructure } from './pass-structure.js';
 import { normalizeSemanticTags } from './semantic-tags.js';
 import { isValidW3CDateString, normalizeDatesDeep } from './w3cdate.js';
 import {
-  validateUpcomingPassInformation,
+  validateUpcomingPassInformationEntries,
   type UpcomingPassInformationEntry,
 } from './upcoming-pass-information.js';
 
@@ -960,9 +960,15 @@ export class PassBase extends PassStructure {
   }
 
   // ─── iOS 26 poster event ticket: upcomingPassInformation ──────────────
-  // Setter validates style + scheme + per-entry shape; dates inside
-  // `dateInformation.date` are normalized to W3C strings by
-  // `normalizeDatesDeep` at toJSON time (see PassBase.toJSON above).
+  // Setter validates per-entry shape (identifier / name / type / image
+  // URLs + SHA256 + size). The cross-field check that the pass is an
+  // eventTicket opted into `posterEventTicket` runs at pass-build time
+  // in `Pass.validate()` via `assertUpcomingPassInformationContext`,
+  // so hydrating a pass from a plain object whose keys happen to put
+  // `upcomingPassInformation` before `preferredStyleSchemes` doesn't
+  // throw during construction. Dates inside `dateInformation.date` are
+  // normalized to W3C strings by `normalizeDatesDeep` at toJSON time
+  // (see PassBase.toJSON above).
 
   get upcomingPassInformation(): UpcomingPassInformationEntry[] | undefined {
     return this.fields.upcomingPassInformation;
@@ -972,9 +978,7 @@ export class PassBase extends PassStructure {
       delete this.fields.upcomingPassInformation;
       return;
     }
-    this.fields.upcomingPassInformation = validateUpcomingPassInformation(
-      v,
-      this.fields,
-    );
+    this.fields.upcomingPassInformation =
+      validateUpcomingPassInformationEntries(v);
   }
 }

--- a/src/lib/base-pass.ts
+++ b/src/lib/base-pass.ts
@@ -11,6 +11,10 @@ import { getGeoPoint } from './get-geo-point.js';
 import { PassStructure } from './pass-structure.js';
 import { normalizeSemanticTags } from './semantic-tags.js';
 import { isValidW3CDateString, normalizeDatesDeep } from './w3cdate.js';
+import {
+  validateUpcomingPassInformation,
+  type UpcomingPassInformationEntry,
+} from './upcoming-pass-information.js';
 
 const STRUCTURE_FIELDS_SET = new Set([...STRUCTURE_FIELDS, 'nfc']);
 
@@ -567,5 +571,410 @@ export class PassBase extends PassStructure {
     else
       for (const location of v)
         this.addLocation(location, location.relevantText);
+  }
+
+  // ─── iOS 18 event-ticket: Event Guide URL keys ─────────────────────────
+  // 12 optional URL fields. `new URL(v)` validates shape only — no scheme
+  // restriction (Apple recommends https but mailto/tel/custom schemes are
+  // accepted in the wild). Contact email and phone are plain strings
+  // (below); they are not URLs.
+
+  get bagPolicyURL(): string | undefined {
+    return this.fields.bagPolicyURL;
+  }
+  set bagPolicyURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.bagPolicyURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.bagPolicyURL = v;
+  }
+
+  get orderFoodURL(): string | undefined {
+    return this.fields.orderFoodURL;
+  }
+  set orderFoodURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.orderFoodURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.orderFoodURL = v;
+  }
+
+  get parkingInformationURL(): string | undefined {
+    return this.fields.parkingInformationURL;
+  }
+  set parkingInformationURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.parkingInformationURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.parkingInformationURL = v;
+  }
+
+  get directionsInformationURL(): string | undefined {
+    return this.fields.directionsInformationURL;
+  }
+  set directionsInformationURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.directionsInformationURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.directionsInformationURL = v;
+  }
+
+  get purchaseParkingURL(): string | undefined {
+    return this.fields.purchaseParkingURL;
+  }
+  set purchaseParkingURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.purchaseParkingURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.purchaseParkingURL = v;
+  }
+
+  get merchandiseURL(): string | undefined {
+    return this.fields.merchandiseURL;
+  }
+  set merchandiseURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.merchandiseURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.merchandiseURL = v;
+  }
+
+  get transitInformationURL(): string | undefined {
+    return this.fields.transitInformationURL;
+  }
+  set transitInformationURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.transitInformationURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.transitInformationURL = v;
+  }
+
+  get accessibilityURL(): string | undefined {
+    return this.fields.accessibilityURL;
+  }
+  set accessibilityURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.accessibilityURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.accessibilityURL = v;
+  }
+
+  get addOnURL(): string | undefined {
+    return this.fields.addOnURL;
+  }
+  set addOnURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.addOnURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.addOnURL = v;
+  }
+
+  get contactVenueWebsite(): string | undefined {
+    return this.fields.contactVenueWebsite;
+  }
+  set contactVenueWebsite(v: string | undefined) {
+    if (!v) {
+      delete this.fields.contactVenueWebsite;
+      return;
+    }
+    void new URL(v);
+    this.fields.contactVenueWebsite = v;
+  }
+
+  get transferURL(): string | undefined {
+    return this.fields.transferURL;
+  }
+  set transferURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.transferURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.transferURL = v;
+  }
+
+  get sellURL(): string | undefined {
+    return this.fields.sellURL;
+  }
+  set sellURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.sellURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.sellURL = v;
+  }
+
+  // ─── iOS 18 event-ticket: plain-string keys ────────────────────────────
+  // Not URLs; stored as strings with delete-on-empty semantics.
+
+  get contactVenueEmail(): string | undefined {
+    return this.fields.contactVenueEmail;
+  }
+  set contactVenueEmail(v: string | undefined) {
+    if (!v) delete this.fields.contactVenueEmail;
+    else this.fields.contactVenueEmail = v;
+  }
+
+  get contactVenuePhoneNumber(): string | undefined {
+    return this.fields.contactVenuePhoneNumber;
+  }
+  set contactVenuePhoneNumber(v: string | undefined) {
+    if (!v) delete this.fields.contactVenuePhoneNumber;
+    else this.fields.contactVenuePhoneNumber = v;
+  }
+
+  get eventLogoText(): string | undefined {
+    return this.fields.eventLogoText;
+  }
+  set eventLogoText(v: string | undefined) {
+    if (!v) delete this.fields.eventLogoText;
+    else this.fields.eventLogoText = v;
+  }
+
+  // ─── iOS 18 event-ticket: styling + misc ──────────────────────────────
+
+  get suppressHeaderDarkening(): boolean {
+    return !!this.fields.suppressHeaderDarkening;
+  }
+  set suppressHeaderDarkening(v: boolean) {
+    if (!v) delete this.fields.suppressHeaderDarkening;
+    else this.fields.suppressHeaderDarkening = true;
+  }
+
+  get useAutomaticColors(): boolean {
+    return !!this.fields.useAutomaticColors;
+  }
+  set useAutomaticColors(v: boolean) {
+    if (!v) delete this.fields.useAutomaticColors;
+    else this.fields.useAutomaticColors = true;
+  }
+
+  // Overrides the chin/footer color in the new event-ticket layout.
+  // Uses the same PassColor machinery as backgroundColor.
+  get footerBackgroundColor():
+    | [number, number, number]
+    | string
+    | undefined
+    | PassColor {
+    if (!(this.fields.footerBackgroundColor instanceof PassColor))
+      return undefined;
+    return this.fields.footerBackgroundColor;
+  }
+  set footerBackgroundColor(
+    v: string | [number, number, number] | undefined | PassColor,
+  ) {
+    if (!v) {
+      delete this.fields.footerBackgroundColor;
+      return;
+    }
+    if (!(this.fields.footerBackgroundColor instanceof PassColor))
+      this.fields.footerBackgroundColor = new PassColor(v);
+    else this.fields.footerBackgroundColor.set(v);
+  }
+
+  // Secondary App Store IDs; filter to integers like
+  // associatedStoreIdentifiers does (drop non-integer / non-number entries).
+  get auxiliaryStoreIdentifiers(): ApplePass['auxiliaryStoreIdentifiers'] {
+    return this.fields.auxiliaryStoreIdentifiers;
+  }
+  set auxiliaryStoreIdentifiers(v: ApplePass['auxiliaryStoreIdentifiers']) {
+    if (!v) {
+      delete this.fields.auxiliaryStoreIdentifiers;
+      return;
+    }
+    const arrayOfNumbers = v.filter(n => Number.isInteger(n));
+    if (arrayOfNumbers.length > 0)
+      this.fields.auxiliaryStoreIdentifiers = arrayOfNumbers;
+    else delete this.fields.auxiliaryStoreIdentifiers;
+  }
+
+  // ─── iOS 26 enhanced / semantic boarding pass: URL keys ───────────────
+
+  get changeSeatURL(): string | undefined {
+    return this.fields.changeSeatURL;
+  }
+  set changeSeatURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.changeSeatURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.changeSeatURL = v;
+  }
+
+  get entertainmentURL(): string | undefined {
+    return this.fields.entertainmentURL;
+  }
+  set entertainmentURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.entertainmentURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.entertainmentURL = v;
+  }
+
+  get purchaseAdditionalBaggageURL(): string | undefined {
+    return this.fields.purchaseAdditionalBaggageURL;
+  }
+  set purchaseAdditionalBaggageURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.purchaseAdditionalBaggageURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.purchaseAdditionalBaggageURL = v;
+  }
+
+  get purchaseLoungeAccessURL(): string | undefined {
+    return this.fields.purchaseLoungeAccessURL;
+  }
+  set purchaseLoungeAccessURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.purchaseLoungeAccessURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.purchaseLoungeAccessURL = v;
+  }
+
+  get purchaseWifiURL(): string | undefined {
+    return this.fields.purchaseWifiURL;
+  }
+  set purchaseWifiURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.purchaseWifiURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.purchaseWifiURL = v;
+  }
+
+  get upgradeURL(): string | undefined {
+    return this.fields.upgradeURL;
+  }
+  set upgradeURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.upgradeURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.upgradeURL = v;
+  }
+
+  get managementURL(): string | undefined {
+    return this.fields.managementURL;
+  }
+  set managementURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.managementURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.managementURL = v;
+  }
+
+  get registerServiceAnimalURL(): string | undefined {
+    return this.fields.registerServiceAnimalURL;
+  }
+  set registerServiceAnimalURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.registerServiceAnimalURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.registerServiceAnimalURL = v;
+  }
+
+  get reportLostBagURL(): string | undefined {
+    return this.fields.reportLostBagURL;
+  }
+  set reportLostBagURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.reportLostBagURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.reportLostBagURL = v;
+  }
+
+  get requestWheelchairURL(): string | undefined {
+    return this.fields.requestWheelchairURL;
+  }
+  set requestWheelchairURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.requestWheelchairURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.requestWheelchairURL = v;
+  }
+
+  get transitProviderWebsiteURL(): string | undefined {
+    return this.fields.transitProviderWebsiteURL;
+  }
+  set transitProviderWebsiteURL(v: string | undefined) {
+    if (!v) {
+      delete this.fields.transitProviderWebsiteURL;
+      return;
+    }
+    void new URL(v);
+    this.fields.transitProviderWebsiteURL = v;
+  }
+
+  // iOS 26 transit provider — contact fields (plain strings, not URLs)
+
+  get transitProviderEmail(): string | undefined {
+    return this.fields.transitProviderEmail;
+  }
+  set transitProviderEmail(v: string | undefined) {
+    if (!v) delete this.fields.transitProviderEmail;
+    else this.fields.transitProviderEmail = v;
+  }
+
+  get transitProviderPhoneNumber(): string | undefined {
+    return this.fields.transitProviderPhoneNumber;
+  }
+  set transitProviderPhoneNumber(v: string | undefined) {
+    if (!v) delete this.fields.transitProviderPhoneNumber;
+    else this.fields.transitProviderPhoneNumber = v;
+  }
+
+  // ─── iOS 26 poster event ticket: upcomingPassInformation ──────────────
+  // Setter validates style + scheme + per-entry shape; dates inside
+  // `dateInformation.date` are normalized to W3C strings by
+  // `normalizeDatesDeep` at toJSON time (see PassBase.toJSON above).
+
+  get upcomingPassInformation(): UpcomingPassInformationEntry[] | undefined {
+    return this.fields.upcomingPassInformation;
+  }
+  set upcomingPassInformation(v: UpcomingPassInformationEntry[] | undefined) {
+    if (!v) {
+      delete this.fields.upcomingPassInformation;
+      return;
+    }
+    this.fields.upcomingPassInformation = validateUpcomingPassInformation(
+      v,
+      this.fields,
+    );
   }
 }

--- a/src/lib/pass-structure.ts
+++ b/src/lib/pass-structure.ts
@@ -23,7 +23,8 @@ type StructureFieldName =
   | 'auxiliaryFields'
   | 'backFields'
   | 'primaryFields'
-  | 'secondaryFields';
+  | 'secondaryFields'
+  | 'additionalInfoFields';
 
 export class PassStructure {
   protected fields: Partial<ApplePass> = {};
@@ -153,5 +154,16 @@ export class PassStructure {
   }
   get secondaryFields(): FieldsMap {
     return this.fieldMap('secondaryFields');
+  }
+
+  // iOS 18 event-ticket dashboard fields. Only valid on eventTicket
+  // passes — mirrors the style gating used by `transitType` (boardingPass)
+  // and `nfc` (storeCard).
+  get additionalInfoFields(): FieldsMap {
+    if (this.style !== 'eventTicket')
+      throw new ReferenceError(
+        `additionalInfoFields only allowed on eventTicket passes, current style is ${this.style}`,
+      );
+    return this.fieldMap('additionalInfoFields');
   }
 }

--- a/src/lib/semantic-tags.ts
+++ b/src/lib/semantic-tags.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2017-2026 Konstantin Vyatkin <tino@vtkn.io>
 
-import type { SemanticTags, SemanticTagValue } from '../interfaces.js';
+import type {
+  SemanticTagObject,
+  SemanticTags,
+  SemanticTagValue,
+} from '../interfaces.js';
 
 import { getW3CDateString } from './w3cdate.js';
 
@@ -49,5 +53,12 @@ function normalizeSemanticValue(
 // recursion path count as a cycle — shared subtrees used in multiple
 // branches are acyclic and serialize normally.
 export function normalizeSemanticTags(tags: SemanticTags): SemanticTags {
-  return normalizeSemanticValue(tags, new Set<object>()) as SemanticTags;
+  // Cast-through: the runtime walker treats any plain object as a
+  // `SemanticTagObject`, but the strictly-typed `SemanticTags` interface
+  // intentionally lacks an index signature. The narrowing is purely a
+  // compile-time safety net; the walk is schema-agnostic.
+  return normalizeSemanticValue(
+    tags as unknown as SemanticTagObject,
+    new Set<object>(),
+  ) as SemanticTags;
 }

--- a/src/lib/upcoming-pass-information.ts
+++ b/src/lib/upcoming-pass-information.ts
@@ -120,29 +120,24 @@ export interface UpcomingPassInformationEntry {
 }
 
 /**
- * Validates a full `upcomingPassInformation` payload against the iOS 26
- * spec. Throws `TypeError` on any rule violation; returns the input
- * array unchanged on success so the caller can inline the result.
+ * Per-entry shape validation for `upcomingPassInformation`. Runs at
+ * setter time and does not look at any other pass field, so it cannot
+ * produce order-dependent failures when a caller hydrates a pass from
+ * a plain object whose key order puts `upcomingPassInformation`
+ * before `preferredStyleSchemes`.
  *
- * Runtime-only — static types in `UpcomingPassInformationEntry` already
- * steer correct shapes; these checks catch cases where consumers build
- * entries dynamically or cast through `any`.
+ * Cross-field checks (eventTicket style + `posterEventTicket` scheme)
+ * live in `assertUpcomingPassInformationContext` and run at pass-build
+ * time, in `Pass.validate()`.
+ *
+ * Throws `TypeError` on any rule violation; returns the input array
+ * unchanged on success.
  */
-export function validateUpcomingPassInformation(
+export function validateUpcomingPassInformationEntries(
   value: UpcomingPassInformationEntry[],
-  pass: Partial<ApplePass>,
 ): UpcomingPassInformationEntry[] {
   if (!Array.isArray(value))
     throw new TypeError('upcomingPassInformation must be an array');
-
-  if (!('eventTicket' in pass))
-    throw new TypeError('upcomingPassInformation requires style "eventTicket"');
-
-  const schemes = pass.preferredStyleSchemes;
-  if (!Array.isArray(schemes) || !schemes.includes('posterEventTicket'))
-    throw new TypeError(
-      'upcomingPassInformation requires preferredStyleSchemes to include "posterEventTicket"',
-    );
 
   for (const [i, entry] of value.entries()) {
     if (!entry || typeof entry !== 'object')
@@ -174,20 +169,60 @@ export function validateUpcomingPassInformation(
             throw new TypeError(
               `upcomingPassInformation[${i}].images.${slot}.URLs[${j}].URL must be a string`,
             );
-          // URL shape validation (throws on malformed); no scheme restriction.
-          void new URL(url.URL);
+          // Apple spec: image URLs must be HTTPS.
+          const parsed = new URL(url.URL);
+          if (parsed.protocol !== 'https:')
+            throw new TypeError(
+              `upcomingPassInformation[${i}].images.${slot}.URLs[${j}].URL must use https`,
+            );
           if (typeof url.SHA256 !== 'string' || !SHA256_HEX.test(url.SHA256))
             throw new TypeError(
               `upcomingPassInformation[${i}].images.${slot}.URLs[${j}].SHA256 must be a 64-char hex string`,
             );
-          if (typeof url.size === 'number' && url.size > MAX_IMAGE_BYTES)
-            throw new TypeError(
-              `upcomingPassInformation[${i}].images.${slot}.URLs[${j}].size exceeds 2 MiB`,
-            );
+          if (url.size !== undefined) {
+            if (
+              typeof url.size !== 'number' ||
+              !Number.isInteger(url.size) ||
+              url.size < 0
+            )
+              throw new TypeError(
+                `upcomingPassInformation[${i}].images.${slot}.URLs[${j}].size must be a non-negative integer`,
+              );
+            if (url.size > MAX_IMAGE_BYTES)
+              throw new TypeError(
+                `upcomingPassInformation[${i}].images.${slot}.URLs[${j}].size exceeds 2 MiB`,
+              );
+          }
         }
       }
     }
   }
 
   return value;
+}
+
+/**
+ * Cross-field context check for `upcomingPassInformation`: the pass
+ * must be an `eventTicket` opted into the `posterEventTicket` scheme.
+ * No-ops if `upcomingPassInformation` is unset.
+ *
+ * Intended to run at pass-build time (from `Pass.validate()`), after
+ * the caller has finished wiring the pass's fields. Keeping this
+ * separate from `validateUpcomingPassInformationEntries` avoids an
+ * order-dependency bug when hydrating a pass from a serialized object
+ * whose key order is not style-first.
+ */
+export function assertUpcomingPassInformationContext(
+  pass: Partial<ApplePass>,
+): void {
+  if (!pass.upcomingPassInformation) return;
+
+  if (!('eventTicket' in pass))
+    throw new TypeError('upcomingPassInformation requires style "eventTicket"');
+
+  const schemes = pass.preferredStyleSchemes;
+  if (!Array.isArray(schemes) || !schemes.includes('posterEventTicket'))
+    throw new TypeError(
+      'upcomingPassInformation requires preferredStyleSchemes to include "posterEventTicket"',
+    );
 }

--- a/src/lib/upcoming-pass-information.ts
+++ b/src/lib/upcoming-pass-information.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2017-2026 Konstantin Vyatkin <tino@vtkn.io>
+
+// iOS 26 `upcomingPassInformation` — declares future events chained to a
+// poster-event-ticket pass. Only valid when:
+//   - pass style is `eventTicket`
+//   - `preferredStyleSchemes` includes `'posterEventTicket'`
+// Dates inside `dateInformation.date` serialize to W3C strings via the
+// existing `normalizeDatesDeep` walker inside `PassBase.toJSON()`; no
+// normalization is done at assignment time.
+//
+// See https://developer.apple.com/documentation/walletpasses/upcomingpassinformationentry
+
+import type { ApplePass, Field, SemanticTags } from '../interfaces.js';
+
+// Apple caps remote image downloads at 2 MiB per entry.
+const MAX_IMAGE_BYTES = 2 * 1024 * 1024;
+
+const SHA256_HEX = /^[0-9a-f]{64}$/i;
+
+/** An individual density variant of a remote image. */
+export interface ImageURLEntry {
+  /** HTTPS URL Wallet downloads at render time. */
+  URL: string;
+  /** Lowercase-hex SHA-256 of the downloaded bytes. */
+  SHA256: string;
+  /** 1, 2, or 3. Defaults to 1 when unspecified. */
+  scale?: 1 | 2 | 3;
+  /** Byte size of the image; must not exceed 2 MiB. */
+  size?: number;
+}
+
+/** Remote image dictionary with one or more density variants. */
+export interface Image {
+  URLs: ImageURLEntry[];
+  /** When `true`, Wallet may reuse a matching local asset if available. */
+  reuseExisting?: boolean;
+}
+
+/** Image slots recognized for an upcoming pass information entry. */
+export interface Images {
+  headerImage?: Image;
+  venueMap?: Image;
+}
+
+/**
+ * URLs embedded in the upcoming entry's event guide. Mirrors the 14
+ * pass-level `PassEventTicketKeys` URL fields.
+ */
+export interface UpcomingURLs {
+  accessibilityURL?: string;
+  addOnURL?: string;
+  bagPolicyURL?: string;
+  contactVenueEmail?: string;
+  contactVenuePhoneNumber?: string;
+  contactVenueWebsite?: string;
+  directionsInformationURL?: string;
+  merchandiseURL?: string;
+  orderFoodURL?: string;
+  parkingInformationURL?: string;
+  purchaseParkingURL?: string;
+  sellURL?: string;
+  transferURL?: string;
+  transitInformationURL?: string;
+}
+
+/** Structured date metadata for an upcoming event. */
+export interface DateInformation {
+  /** ISO-8601 / W3C string or `Date`. Required. */
+  date: string | Date;
+  /** IANA time zone name (e.g. `America/New_York`). */
+  timeZone?: string;
+  /** When `true`, the pass displays only the date, not the time. */
+  ignoreTimeComponents?: boolean;
+  /** When `true`, the system treats the event as all-day. */
+  isAllDay?: boolean;
+  /** When `true`, the pass shows "Time TBA". */
+  isUnannounced?: boolean;
+  /** When `true`, the pass shows the date as undetermined. */
+  isUndetermined?: boolean;
+}
+
+/**
+ * Per-entry semantic tags. Uses the pass-level `SemanticTags` shape plus
+ * the MapKit Place ID field unique to upcoming entries.
+ */
+export type UpcomingEntrySemantics = SemanticTags & {
+  venuePlaceID?: string;
+};
+
+export type UpcomingPassInformationType = 'event';
+
+/** A single upcoming pass information entry. */
+export interface UpcomingPassInformationEntry {
+  /** Stable unique identifier; Wallet uses this to chain updates. */
+  identifier: string;
+  /** Human-readable name of the upcoming event. */
+  name: string;
+  /** Must equal `'event'` (reserved for future values). */
+  type: UpcomingPassInformationType;
+  /** Fields shown on the entry's details view. */
+  additionalInfoFields?: Field[];
+  /**
+   * App Store identifiers associated with this specific upcoming entry.
+   * The first ID compatible with the device is used.
+   */
+  auxiliaryStoreIdentifiers?: number[];
+  /** Fields shown on the back of the entry's details view. */
+  backFields?: Field[];
+  /** Start/end timing metadata; if omitted, entry is labeled TBD. */
+  dateInformation?: DateInformation;
+  /** Remote images to render in the details view. */
+  images?: Images;
+  /** When `true`, the entry is currently active. Defaults to `false`. */
+  isActive?: boolean;
+  /** Per-entry semantic tags. */
+  semantics?: UpcomingEntrySemantics;
+  /** URLs for the event guide of this upcoming entry. */
+  URLs?: UpcomingURLs;
+}
+
+/**
+ * Validates a full `upcomingPassInformation` payload against the iOS 26
+ * spec. Throws `TypeError` on any rule violation; returns the input
+ * array unchanged on success so the caller can inline the result.
+ *
+ * Runtime-only — static types in `UpcomingPassInformationEntry` already
+ * steer correct shapes; these checks catch cases where consumers build
+ * entries dynamically or cast through `any`.
+ */
+export function validateUpcomingPassInformation(
+  value: UpcomingPassInformationEntry[],
+  pass: Partial<ApplePass>,
+): UpcomingPassInformationEntry[] {
+  if (!Array.isArray(value))
+    throw new TypeError('upcomingPassInformation must be an array');
+
+  if (!('eventTicket' in pass))
+    throw new TypeError('upcomingPassInformation requires style "eventTicket"');
+
+  const schemes = pass.preferredStyleSchemes;
+  if (!Array.isArray(schemes) || !schemes.includes('posterEventTicket'))
+    throw new TypeError(
+      'upcomingPassInformation requires preferredStyleSchemes to include "posterEventTicket"',
+    );
+
+  for (const [i, entry] of value.entries()) {
+    if (!entry || typeof entry !== 'object')
+      throw new TypeError(`upcomingPassInformation[${i}] must be an object`);
+
+    if (typeof entry.identifier !== 'string' || entry.identifier.length === 0)
+      throw new TypeError(
+        `upcomingPassInformation[${i}].identifier must be a non-empty string`,
+      );
+
+    if (typeof entry.name !== 'string' || entry.name.length === 0)
+      throw new TypeError(
+        `upcomingPassInformation[${i}].name must be a non-empty string`,
+      );
+
+    if (entry.type !== 'event')
+      throw new TypeError(`upcomingPassInformation[${i}].type must be "event"`);
+
+    if (entry.images) {
+      for (const slot of Object.keys(entry.images) as (keyof Images)[]) {
+        const img = entry.images[slot];
+        if (!img) continue;
+        if (!Array.isArray(img.URLs) || img.URLs.length === 0)
+          throw new TypeError(
+            `upcomingPassInformation[${i}].images.${slot}.URLs must be a non-empty array`,
+          );
+        for (const [j, url] of img.URLs.entries()) {
+          if (typeof url.URL !== 'string')
+            throw new TypeError(
+              `upcomingPassInformation[${i}].images.${slot}.URLs[${j}].URL must be a string`,
+            );
+          // URL shape validation (throws on malformed); no scheme restriction.
+          void new URL(url.URL);
+          if (typeof url.SHA256 !== 'string' || !SHA256_HEX.test(url.SHA256))
+            throw new TypeError(
+              `upcomingPassInformation[${i}].images.${slot}.URLs[${j}].SHA256 must be a 64-char hex string`,
+            );
+          if (typeof url.size === 'number' && url.size > MAX_IMAGE_BYTES)
+            throw new TypeError(
+              `upcomingPassInformation[${i}].images.${slot}.URLs[${j}].size exceeds 2 MiB`,
+            );
+        }
+      }
+    }
+  }
+
+  return value;
+}

--- a/src/lib/upcoming-pass-information.ts
+++ b/src/lib/upcoming-pass-information.ts
@@ -179,6 +179,13 @@ export function validateUpcomingPassInformationEntries(
             throw new TypeError(
               `upcomingPassInformation[${i}].images.${slot}.URLs[${j}].SHA256 must be a 64-char hex string`,
             );
+          if (
+            url.scale !== undefined &&
+            !(url.scale === 1 || url.scale === 2 || url.scale === 3)
+          )
+            throw new TypeError(
+              `upcomingPassInformation[${i}].images.${slot}.URLs[${j}].scale must be 1, 2, or 3`,
+            );
           if (url.size !== undefined) {
             if (
               typeof url.size !== 'number' ||

--- a/src/pass.ts
+++ b/src/pass.ts
@@ -11,6 +11,7 @@ import { writeZip, type ZipWriteEntry } from './lib/zip.js';
 import type { ApplePass, Options } from './interfaces.js';
 import type { Template } from './template.js';
 import type { Localizations } from './lib/localizations.js';
+import { assertUpcomingPassInformationContext } from './lib/upcoming-pass-information.js';
 
 // Create a new pass.
 //
@@ -59,6 +60,10 @@ export class Pass extends PassBase {
         'authenticationToken is present in Pass data while webServiceURL is missing!',
       );
     }
+
+    // Cross-field check deferred from the `upcomingPassInformation`
+    // setter — runs here so construction order doesn't matter.
+    assertUpcomingPassInformationContext(this.fields);
 
     this.images.validate();
   }


### PR DESCRIPTION
## Summary

- Adds **33 new top-level `pass.json` keys** (14 iOS 18 event-ticket
  Event Guide URLs + styling flags + misc, 13 iOS 26 enhanced boarding
  pass URLs + transit-provider contacts, plus the
  `upcomingPassInformation` structure) and `additionalInfoFields`
  on `eventTicket`.
- Tightens `SemanticTags` from an opaque `{ [k: string]: SemanticTagValue }`
  into a strict interface covering every documented Apple Wallet tag
  through iOS 26 (pre-iOS-18 baseline + iOS 18 + iOS 26, ~95 fields).
- All additive at runtime; `pass.json` emitted by existing code is
  byte-identical (the existing snapshot test passes without
  regeneration).

## What's in the box

### iOS 18 event-ticket (P0)

| Category | Keys |
|---|---|
| Event Guide URLs | `bagPolicyURL`, `orderFoodURL`, `parkingInformationURL`, `directionsInformationURL`, `purchaseParkingURL`, `merchandiseURL`, `transitInformationURL`, `accessibilityURL`, `addOnURL`, `contactVenueWebsite`, `transferURL`, `sellURL` |
| Contact (plain strings) | `contactVenueEmail`, `contactVenuePhoneNumber`, `eventLogoText` (iOS 18.1) |
| Styling / misc | `suppressHeaderDarkening`, `useAutomaticColors`, `footerBackgroundColor` (`PassColor`), `auxiliaryStoreIdentifiers` (integer-filtered) |
| Structure | `additionalInfoFields` on `eventTicket` (ReferenceError on other styles, mirroring `transitType`/`nfc`) |
| Schemes | `preferredStyleSchemes` union widened to include `'boardingPass'` / `'semanticBoardingPass'` |

### iOS 26 enhanced / semantic boarding pass (P1)

| Category | Keys |
|---|---|
| URLs | `changeSeatURL`, `entertainmentURL`, `purchaseAdditionalBaggageURL`, `purchaseLoungeAccessURL`, `purchaseWifiURL`, `upgradeURL`, `managementURL`, `registerServiceAnimalURL`, `reportLostBagURL`, `requestWheelchairURL`, `transitProviderWebsiteURL` |
| Contact | `transitProviderEmail`, `transitProviderPhoneNumber` |

### iOS 26 `upcomingPassInformation` (P2)

New `src/lib/upcoming-pass-information.ts`:

- Typed interfaces: `UpcomingPassInformationEntry`, `UpcomingURLs`,
  `Images` + `Image` + `ImageURLEntry`, `DateInformation`,
  `UpcomingEntrySemantics`.
- `validateUpcomingPassInformation(value, pass)` runtime validator.
  Gates:
  - `style === 'eventTicket'`
  - `preferredStyleSchemes` includes `'posterEventTicket'`
  - per-entry: `identifier` / `name` non-empty, `type === 'event'`,
    image `SHA256` is 64-char hex, image `size ≤ 2 MiB`, image URL
    shape validates via `new URL`.
- Setter on `PassBase`; dates inside `dateInformation.date` serialize
  through the existing `normalizeDatesDeep` walker at `toJSON` time.

### Typed `SemanticTags`

- Replaces the opaque index-signature type with a strict interface.
  Unknown keys now produce **TS2322** at compile time.
- **Not released as breaking** — narrowing only rejects keys Apple has
  never documented (i.e. typos and invented tags that Wallet was
  silently dropping anyway). No runtime change for any code writing
  valid `pass.json`.
- Escape hatch for undocumented tags: cast the dictionary through
  `SemanticTagObject` at the assignment site.
- New helper sub-types + enums re-exported from `src/index.ts`:
  `CurrencyAmount`, `EventDateInfo`, `PersonNameComponents`, `Seat`
  (with iOS 18 `seatAisle` / `seatLevel` / `seatSectionColor`),
  `SemanticLocation`, `WifiNetwork`, `PKTransitSecurityProgram`,
  `PKPassengerCapability`.

## Test plan

- [x] `npm run build` passes (tsgo clean)
- [x] `npm run lint` clean (oxlint + oxfmt)
- [x] `npm test` — 106 pass, 1 skipped (pre-existing APN live-push
      test), 0 fail
- [x] `__tests__/pass.ts.snapshot` `generated pass bundle > contains
      pass.json` remains byte-identical (new keys don't leak into
      serialized output for passes that don't set them)
- [x] `__tests__/base-pass.ts` — 24 tests (11 new for P0/P1 + 13
      existing)
- [x] `__tests__/upcoming-pass-information.ts` (new) — 12 tests
      covering happy path + all 11 validation throw-paths
- [ ] Manual QA on an iPhone running iOS 18 / iOS 26 with a real
      Pass Type ID cert — confirm new keys render in the new
      poster event ticket / semantic boarding pass layouts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS 18 event-ticket fields and additionalInfoFields (event-only) plus iOS 26 enhanced/semantic boarding-pass fields and upcomingPassInformation support.
  * Expanded semantic-tag typings and broader exported types for richer structured data.

* **Validation / Behavior**
  * New runtime validations for upcomingPassInformation, images, URLs, sizes, scales, and cross-field style gating; validation enforced during pass validation.

* **Documentation**
  * Added comprehensive gap-analysis comparing feature coverage and priorities.

* **Tests**
  * Extensive coverage for iOS 18/26 features, serialization, and cross-field checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinovyatkin/pass-js/pull/664)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->