### PR TITLE
[codex] replace pkijs CMS signer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,15 +77,11 @@ jobs:
       - run: npm run build
       - name: esbuild single-file bundle (Lambda-style)
         run: |
-          # --banner injects a createRequire shim so bundled CJS modules
-          # (e.g. @noble/hashes → node:crypto) can still resolve node
-          # builtins when the output format is ESM.
           npx esbuild dist/index.js \
             --bundle \
             --platform=node \
             --format=esm \
             --target=node24 \
-            --banner:js="import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);" \
             --outfile=/tmp/bundle.mjs
           # Load the bundle from outside the repo so we prove it doesn't
           # depend on node_modules being present at runtime.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ src/
     images.ts       — image validation + localized variants
     localizations.ts — .lproj strings + UTF-16 LE serialization
     zip.ts          — in-repo ZIP reader + STORE writer (replaces yauzl + do-not-zip)
-    sign-manifest.ts — PKCS#7 SignedData via pkijs + node:crypto; WWDR G4 inlined
+    sign-manifest.ts — PKCS#7 SignedData via minimal in-repo CMS writer + node:crypto; WWDR G4 inlined
     nfc-fields.ts   — NFC dictionary helpers
     semantic-tags.ts — recursive Date→W3C normalization for iOS 18 semantics
     pass-color.ts   — parse 'rgb(...)', '#FFF', named colors into triplets
@@ -87,6 +87,12 @@ src/
   deliberately SHA-1; Apple's pkpass spec requires it. Don't bump to
   SHA-256. The PKCS#7 signature over `manifest.json` is what carries
   authenticity.
+
+- **PKCS#7/CMS signing is intentionally narrow.** `src/lib/sign-manifest.ts`
+  uses a minimal in-repo DER/CMS writer plus `node:crypto` for the single
+  detached SignedData shape this library emits. If Node adds native
+  CMS/PKCS#7 signing support, prefer replacing the internal writer with
+  that API instead of expanding the custom implementation.
 
 - **Tests import from `dist/`, not `src/`.** Node's native TS strip mode
   doesn't rewrite internal `.js` import specifiers, so `npm test` builds

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ release pipeline**, so please follow it:
 | `fix:` | patch | Bug Fixes | `fix: reject invalid Date in semantics` |
 | `perf:` | patch | Performance | `perf: cache CRC table at module load` |
 | `feat!:` or `BREAKING CHANGE:` footer | **major** | Features + BREAKING note | `feat!: drop Node < 24` |
-| `deps:` | patch | Dependencies | `deps: bump pkijs 3.4 → 3.5` |
+| `deps:` | patch | Dependencies | `deps: bump oxlint 1.63 → 1.64` |
 | `docs:`, `refactor:`, `test:`, `ci:`, `chore:`, `build:`, `style:` | — | hidden | `docs: clarify WWDR rotation flow` |
 
 Scopes are optional (`feat(nfc): ...`). Keep the subject line ≤ 72 chars.

--- a/__tests__/der.ts
+++ b/__tests__/der.ts
@@ -86,6 +86,28 @@ test('malformed X.509 DER throws a clear error', () => {
   );
 });
 
+test('X.509 extraction rejects child elements outside parent bounds', () => {
+  const serialOverrunsTbs = testSequence(
+    Buffer.from('30020202123430003000', 'hex'),
+    Buffer.from('3000', 'hex'),
+    Buffer.from('030100', 'hex'),
+  );
+  assert.throws(
+    () => extractCertificateInfo(serialOverrunsTbs),
+    /first tbsCertificate field exceeds tbsCertificate bounds/,
+  );
+
+  const versionOverrunsWrapper = testSequence(
+    Buffer.from('3008a002020201020201', 'hex'),
+    Buffer.from('3000', 'hex'),
+    Buffer.from('030100', 'hex'),
+  );
+  assert.throws(
+    () => extractCertificateInfo(versionOverrunsWrapper),
+    /certificate version exceeds certificate version wrapper bounds/,
+  );
+});
+
 function makeGeneratedCertificate(version: 1 | 3): {
   der: Buffer;
   pemPath: string;

--- a/__tests__/der.ts
+++ b/__tests__/der.ts
@@ -1,0 +1,302 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createSign } from 'node:crypto';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  contextSpecificConstructed,
+  encodeLength,
+  extractCertificateInfo,
+  objectIdentifier,
+  utcTime,
+} from '../dist/lib/der.js';
+
+const CMS_OIDS = new Map([
+  ['1.2.840.113549.1.9.3', '06092a864886f70d010903'],
+  ['1.2.840.113549.1.9.4', '06092a864886f70d010904'],
+  ['1.2.840.113549.1.9.5', '06092a864886f70d010905'],
+  ['1.2.840.113549.1.7.1', '06092a864886f70d010701'],
+  ['1.2.840.113549.1.7.2', '06092a864886f70d010702'],
+  ['1.3.14.3.2.26', '06052b0e03021a'],
+  ['1.2.840.113549.1.1.1', '06092a864886f70d010101'],
+]);
+
+test('DER length encoding uses short and long forms', () => {
+  assert.equal(encodeLength(0).toString('hex'), '00');
+  assert.equal(encodeLength(127).toString('hex'), '7f');
+  assert.equal(encodeLength(128).toString('hex'), '8180');
+  assert.equal(encodeLength(255).toString('hex'), '81ff');
+  assert.equal(encodeLength(256).toString('hex'), '820100');
+  assert.equal(encodeLength(65_535).toString('hex'), '82ffff');
+  assert.equal(encodeLength(65_536).toString('hex'), '83010000');
+});
+
+test('DER OID encoder covers the CMS OIDs pass-js emits', () => {
+  for (const [oid, expected] of CMS_OIDS)
+    assert.equal(objectIdentifier(oid).toString('hex'), expected);
+});
+
+test('DER UTCTime encoder formats UTC timestamps', () => {
+  const date = new Date(Date.UTC(2026, 4, 10, 11, 12, 13));
+  assert.equal(utcTime(date).toString('hex'), '170d3236303531303131313231335a');
+  assert.throws(
+    () => utcTime(new Date(Date.UTC(2050, 0, 1))),
+    /UTCTime year out of range/,
+  );
+});
+
+test('DER context-specific constructed wrapper encodes [0]', () => {
+  const inner = Buffer.from([0x02, 0x01, 0x01]);
+  assert.equal(
+    contextSpecificConstructed(0, inner).toString('hex'),
+    'a003020101',
+  );
+});
+
+test('X.509 extraction handles generated v1 and v3 certificates', () => {
+  for (const version of [1, 3] as const) {
+    const cert = makeGeneratedCertificate(version);
+    const info = extractCertificateInfo(cert.der);
+
+    assert.equal(info.rawCertificate.toString('hex'), cert.der.toString('hex'));
+    assert.equal(info.serialNumber[0], 0x02);
+    assert.equal(info.issuer[0], 0x30);
+    assert.match(
+      info.issuer.toString('utf8'),
+      new RegExp(`pass-js issuer v${version}`),
+    );
+    assert.equal(
+      serialValueHex(info.serialNumber),
+      certificateSerialHex(cert.pemPath),
+    );
+    assert.match(
+      certificateText(cert.pemPath),
+      new RegExp(`Version:\\s+${version} `),
+    );
+  }
+});
+
+test('malformed X.509 DER throws a clear error', () => {
+  assert.throws(
+    () => extractCertificateInfo(Buffer.from('3003020101', 'hex')),
+    /Failed to parse X\.509 certificate DER/,
+  );
+});
+
+function makeGeneratedCertificate(version: 1 | 3): {
+  der: Buffer;
+  pemPath: string;
+} {
+  const dir = mkdtempSync(join(tmpdir(), `pass-js-x509-v${version}-`));
+  const keyPath = join(dir, 'key.pem');
+  const pemPath = join(dir, 'cert.pem');
+  const derPath = join(dir, 'cert.der');
+  const subject = `/CN=pass-js issuer v${version}/O=pass-js test`;
+
+  if (version === 1) {
+    const publicKeyPath = join(dir, 'public.der');
+    execFileSync(
+      'openssl',
+      [
+        'genpkey',
+        '-algorithm',
+        'RSA',
+        '-pkeyopt',
+        'rsa_keygen_bits:2048',
+        '-out',
+        keyPath,
+      ],
+      { stdio: 'ignore' },
+    );
+    execFileSync('openssl', [
+      'pkey',
+      '-in',
+      keyPath,
+      '-pubout',
+      '-outform',
+      'DER',
+      '-out',
+      publicKeyPath,
+    ]);
+
+    const der = makeV1CertificateDer(
+      readFileSync(keyPath),
+      readFileSync(publicKeyPath),
+    );
+    writeFileSync(derPath, der);
+    execFileSync('openssl', [
+      'x509',
+      '-inform',
+      'DER',
+      '-in',
+      derPath,
+      '-out',
+      pemPath,
+    ]);
+  } else {
+    execFileSync(
+      'openssl',
+      [
+        'req',
+        '-x509',
+        '-newkey',
+        'rsa:2048',
+        '-keyout',
+        keyPath,
+        '-out',
+        pemPath,
+        '-days',
+        '1',
+        '-nodes',
+        '-subj',
+        subject,
+        '-addext',
+        'basicConstraints=critical,CA:false',
+      ],
+      { stdio: 'ignore' },
+    );
+  }
+
+  execFileSync('openssl', [
+    'x509',
+    '-in',
+    pemPath,
+    '-outform',
+    'DER',
+    '-out',
+    derPath,
+  ]);
+
+  return { der: readFileSync(derPath), pemPath };
+}
+
+function makeV1CertificateDer(
+  privateKey: Buffer,
+  publicKeyInfo: Buffer,
+): Buffer {
+  const signatureAlgorithm = Buffer.from(
+    '300d06092a864886f70d01010b0500',
+    'hex',
+  );
+  const issuer = testName('pass-js issuer v1');
+  const validity = testSequence(
+    testUtcTime('260101000000Z'),
+    testUtcTime('270101000000Z'),
+  );
+  const serialNumber = Buffer.from('02021234', 'hex');
+  const tbsCertificate = testSequence(
+    serialNumber,
+    signatureAlgorithm,
+    issuer,
+    validity,
+    issuer,
+    publicKeyInfo,
+  );
+  const signature = createSign('sha256')
+    .update(tbsCertificate)
+    .sign(privateKey);
+
+  return testSequence(
+    tbsCertificate,
+    signatureAlgorithm,
+    testTlv(0x03, Buffer.concat([Buffer.from([0]), signature])),
+  );
+}
+
+function testName(commonName: string): Buffer {
+  return testSequence(
+    testSet(
+      testSequence(
+        Buffer.from('0603550403', 'hex'),
+        testUtf8String(commonName),
+      ),
+    ),
+    testSet(
+      testSequence(
+        Buffer.from('060355040a', 'hex'),
+        testUtf8String('pass-js test'),
+      ),
+    ),
+  );
+}
+
+function testUtf8String(value: string): Buffer {
+  return testTlv(0x0c, Buffer.from(value, 'utf8'));
+}
+
+function testUtcTime(value: string): Buffer {
+  return testTlv(0x17, Buffer.from(value, 'ascii'));
+}
+
+function testSequence(...values: Buffer[]): Buffer {
+  return testTlv(0x30, Buffer.concat(values));
+}
+
+function testSet(...values: Buffer[]): Buffer {
+  return testTlv(0x31, Buffer.concat(values));
+}
+
+function testTlv(tag: number, content: Buffer): Buffer {
+  return Buffer.concat([
+    Buffer.from([tag]),
+    testLength(content.length),
+    content,
+  ]);
+}
+
+function testLength(length: number): Buffer {
+  if (length < 0x80) return Buffer.from([length]);
+
+  const bytes: number[] = [];
+  let remaining = length;
+  while (remaining > 0) {
+    bytes.unshift(remaining & 0xff);
+    remaining = Math.floor(remaining / 0x100);
+  }
+  return Buffer.from([0x80 | bytes.length, ...bytes]);
+}
+
+function certificateSerialHex(pemPath: string): string {
+  return execFileSync(
+    'openssl',
+    ['x509', '-in', pemPath, '-noout', '-serial'],
+    {
+      encoding: 'utf8',
+    },
+  )
+    .trim()
+    .replace(/^serial=/, '')
+    .toLowerCase();
+}
+
+function certificateText(pemPath: string): string {
+  return execFileSync('openssl', ['x509', '-in', pemPath, '-noout', '-text'], {
+    encoding: 'utf8',
+  });
+}
+
+function serialValueHex(serialDer: Buffer): string {
+  const firstLength = serialDer[1];
+  if (firstLength === undefined) throw new Error('Missing serial DER length');
+
+  let offset = 2;
+  let length = firstLength;
+  if ((firstLength & 0x80) !== 0) {
+    const lengthOctets = firstLength & 0x7f;
+    length = 0;
+    for (let i = 0; i < lengthOctets; i += 1) {
+      const byte = serialDer[offset + i];
+      if (byte === undefined) throw new Error('Truncated serial DER length');
+      length = length * 0x100 + byte;
+    }
+    offset += lengthOctets;
+  }
+
+  return serialDer
+    .subarray(offset, offset + length)
+    .toString('hex')
+    .replace(/^00/, '');
+}

--- a/__tests__/signManifest.ts
+++ b/__tests__/signManifest.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -13,12 +13,26 @@ import { Template } from '../dist/template.js';
 // Previously the test relied on APPLE_PASS_* env vars that have been expired
 // since 2020; this version is self-contained.
 function makeTestKeypair(): { certPem: string; keyPem: string } {
-  const dir = tmpdir();
-  const keyPath = join(dir, `pass-js-test-${process.pid}.key`);
-  const certPath = join(dir, `pass-js-test-${process.pid}.crt`);
-  execSync(
-    `openssl req -x509 -newkey rsa:2048 -keyout ${keyPath} -out ${certPath} ` +
-      `-days 1 -nodes -subj "/CN=Pass Type ID: pass.test/O=pass-js test"`,
+  const dir = mkdtempSync(join(tmpdir(), 'pass-js-sign-'));
+  const keyPath = join(dir, 'key.pem');
+  const certPath = join(dir, 'cert.pem');
+  execFileSync(
+    'openssl',
+    [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      keyPath,
+      '-out',
+      certPath,
+      '-days',
+      '1',
+      '-nodes',
+      '-subj',
+      '/CN=Pass Type ID: pass.test/O=pass-js test',
+    ],
     { stdio: 'ignore' },
   );
   return {
@@ -42,13 +56,66 @@ test('signManifest produces a valid detached PKCS#7 signature', () => {
   assert.ok(signature.length > 0, 'signature non-empty');
 
   // Round-trip: openssl cms -verify must succeed against the signing cert.
-  const dir = tmpdir();
-  const sigPath = join(dir, `pass-js-sig-${process.pid}.der`);
-  const manPath = join(dir, `pass-js-man-${process.pid}.txt`);
+  const dir = mkdtempSync(join(tmpdir(), 'pass-js-cms-'));
+  const sigPath = join(dir, 'signature.der');
+  const manPath = join(dir, 'manifest.txt');
   writeFileSync(sigPath, signature);
   writeFileSync(manPath, manifest);
-  const out = execSync(
-    `openssl cms -verify -binary -inform DER -content ${manPath} -in ${sigPath} -noverify 2>&1`,
-  ).toString();
-  assert.match(out, /Verification successful|CMS Verification successful/);
+
+  const verify = spawnSync(
+    'openssl',
+    [
+      'cms',
+      '-verify',
+      '-binary',
+      '-inform',
+      'DER',
+      '-content',
+      manPath,
+      '-in',
+      sigPath,
+      '-noverify',
+    ],
+    { encoding: 'utf8' },
+  );
+  const verifyOutput = `${verify.stdout}\n${verify.stderr}`;
+  assert.equal(verify.status, 0, verifyOutput);
+  assert.match(
+    verifyOutput,
+    /Verification successful|CMS Verification successful/,
+  );
+
+  const asn1 = execFileSync(
+    'openssl',
+    ['asn1parse', '-inform', 'DER', '-in', sigPath, '-i'],
+    { encoding: 'utf8' },
+  );
+  assert.match(asn1, /OBJECT\s+:pkcs7-signedData/);
+  assert.match(asn1, /OBJECT\s+:pkcs7-data/);
+  assert.match(asn1, /OBJECT\s+:contentType/);
+  assert.match(asn1, /OBJECT\s+:messageDigest/);
+  assert.match(asn1, /OBJECT\s+:signingTime/);
+  assert.match(asn1, /OBJECT\s+:rsaEncryption/);
+  assert.match(asn1, /prim:\s+OCTET STRING/);
+
+  const cmsPrint = execFileSync(
+    'openssl',
+    ['cms', '-cmsout', '-print', '-inform', 'DER', '-in', sigPath],
+    { encoding: 'utf8' },
+  );
+  assert.match(cmsPrint, /eContentType: pkcs7-data/);
+  assert.match(cmsPrint, /eContent: <ABSENT>/);
+  assert.match(cmsPrint, /signedAttrs:/);
+
+  const certs = execFileSync(
+    'openssl',
+    ['pkcs7', '-inform', 'DER', '-in', sigPath, '-print_certs'],
+    { encoding: 'utf8' },
+  );
+  assert.equal(certs.match(/BEGIN CERTIFICATE/g)?.length, 2);
+  assert.match(certs, /subject=.*Pass Type ID: pass\.test/);
+  assert.match(
+    certs,
+    /subject=.*Apple Worldwide Developer Relations Certification Authority/,
+  );
 });

--- a/docs/passkit-generator-gap-analysis.md
+++ b/docs/passkit-generator-gap-analysis.md
@@ -16,8 +16,8 @@ not the focus.
 
 ## 1. Executive summary
 
-`pass-js` has a tighter, more modern runtime core (native `node:crypto`
-PKCS#7 via `pkijs` instead of `node-forge`, in-repo ZIP reader/writer
+`pass-js` has a tighter, more modern runtime core (minimal in-repo CMS
+writer + `node:crypto` instead of `node-forge`, in-repo ZIP reader/writer
 instead of `yauzl`+`do-not-zip`, full ESM, PNG dimension validation,
 APN push via `http2`, WWDR cert rotation warnings). `passkit-generator`
 has broader **schema coverage** — particularly for iOS 18 event ticket
@@ -52,7 +52,8 @@ The largest functional gaps, in decreasing priority:
 which should be preserved while closing the gaps:
 
 - No `node-forge` dependency (CVE-prone historically); signature chain
-  is `pkijs` + `node:crypto`.
+  is a minimal in-repo CMS writer + `node:crypto`. If Node adds native
+  CMS/PKCS#7 signing support, replace the internal writer with that API.
 - Bundled WWDR G4 with `process.emitWarning` 90 days before expiry.
 - Own ZIP reader/writer (works with Lambda / Cloudflare Workers without
   native modules).
@@ -189,7 +190,7 @@ misspelled.
 
 | Capability | `pass-js` | `passkit-generator` |
 |---|---|---|
-| PKCS#7 detached SignedData over `manifest.json` | ✅ `pkijs` + `node:crypto` | ✅ `node-forge` |
+| PKCS#7 detached SignedData over `manifest.json` | ✅ minimal in-repo CMS writer + `node:crypto` | ✅ `node-forge` |
 | WWDR bundled | ✅ G4, PEM inlined with rotation warning hooked into `process.emitWarning` at 90-day window | ❌ — caller must supply every time |
 | WWDR override for dev | ✅ `APPLE_WWDR_CERT_PEM` env var | n/a |
 | Encrypted private key handling | ✅ via `createPrivateKey({ passphrase })` | ✅ via forge's `decryptRsaPrivateKey` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "color-name": "^2.0.0",
-        "pkijs": "^3.4.0",
         "strip-json-comments": "^5.0.3"
       },
       "bin": {
@@ -29,18 +28,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/walletpass"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
@@ -972,29 +959,6 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/asn1js": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
-      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.5",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/bytestreamjs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
-      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/color-name": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
@@ -1107,41 +1071,6 @@
         "@oxlint-tsgolint/win32-x64": "0.22.1"
       }
     },
-    "node_modules/pkijs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
-      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@noble/hashes": "1.4.0",
-        "asn1js": "^3.0.6",
-        "bytestreamjs": "^2.0.1",
-        "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/pvtsutils": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
-      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/pvutils": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
@@ -1163,12 +1092,6 @@
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "color-name": "^2.0.0",
-    "pkijs": "^3.4.0",
     "strip-json-comments": "^5.0.3"
   },
   "keywords": [

--- a/src/lib/der.ts
+++ b/src/lib/der.ts
@@ -181,24 +181,54 @@ export function extractCertificateInfo(
     expectTag(tbsCertificate, 0x30, 'tbsCertificate');
 
     let cursor = tbsCertificate.contentStart;
-    const firstTbsField = readDerElement(der, cursor);
+    const firstTbsField = readChildElement(
+      der,
+      cursor,
+      tbsCertificate,
+      'first tbsCertificate field',
+      'tbsCertificate',
+    );
     if (firstTbsField.tag === 0xa0) {
-      const version = readDerElement(der, firstTbsField.contentStart);
+      const version = readChildElement(
+        der,
+        firstTbsField.contentStart,
+        firstTbsField,
+        'certificate version',
+        'certificate version wrapper',
+      );
       expectTag(version, 0x02, 'certificate version');
       if (version.end !== firstTbsField.end)
         throw new Error('certificate version field has trailing data');
       cursor = firstTbsField.end;
     }
 
-    const serialNumber = readDerElement(der, cursor);
+    const serialNumber = readChildElement(
+      der,
+      cursor,
+      tbsCertificate,
+      'certificate serialNumber',
+      'tbsCertificate',
+    );
     expectTag(serialNumber, 0x02, 'certificate serialNumber');
     cursor = serialNumber.end;
 
-    const signature = readDerElement(der, cursor);
+    const signature = readChildElement(
+      der,
+      cursor,
+      tbsCertificate,
+      'certificate signature algorithm',
+      'tbsCertificate',
+    );
     expectTag(signature, 0x30, 'certificate signature algorithm');
     cursor = signature.end;
 
-    const issuer = readDerElement(der, cursor);
+    const issuer = readChildElement(
+      der,
+      cursor,
+      tbsCertificate,
+      'certificate issuer',
+      'tbsCertificate',
+    );
     expectTag(issuer, 0x30, 'certificate issuer');
 
     return {
@@ -213,6 +243,23 @@ export function extractCertificateInfo(
       cause: error,
     });
   }
+}
+
+function readChildElement(
+  input: Buffer,
+  offset: number,
+  parent: DerElement,
+  label: string,
+  parentLabel: string,
+): DerElement {
+  if (offset < parent.contentStart || offset >= parent.end)
+    throw new Error(`${label} starts outside ${parentLabel} bounds`);
+
+  const element = readDerElement(input, offset);
+  if (element.end > parent.end)
+    throw new Error(`${label} exceeds ${parentLabel} bounds`);
+
+  return element;
 }
 
 function readDerElement(input: Buffer, offset: number): DerElement {

--- a/src/lib/der.ts
+++ b/src/lib/der.ts
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2017-2026 Konstantin Vyatkin <tino@vtkn.io>
+
+export interface X509CertificateDerInfo {
+  rawCertificate: Buffer;
+  tbsCertificate: Buffer;
+  serialNumber: Buffer;
+  issuer: Buffer;
+}
+
+interface DerElement {
+  tag: number;
+  contentStart: number;
+  end: number;
+  raw: Buffer;
+}
+
+export function rawDer(value: Buffer | Uint8Array): Buffer {
+  return Buffer.from(value);
+}
+
+export function encodeLength(length: number): Buffer {
+  if (!Number.isSafeInteger(length) || length < 0)
+    throw new RangeError(`Invalid DER length: ${length}`);
+
+  if (length < 0x80) return Buffer.from([length]);
+
+  const bytes: number[] = [];
+  let remaining = length;
+  while (remaining > 0) {
+    bytes.unshift(remaining & 0xff);
+    remaining = Math.floor(remaining / 0x100);
+  }
+
+  return Buffer.from([0x80 | bytes.length, ...bytes]);
+}
+
+function encodeTlv(tag: number, content: Buffer): Buffer {
+  if (!Number.isInteger(tag) || tag < 0 || tag > 0xff)
+    throw new RangeError(`Invalid DER tag: ${tag}`);
+
+  return Buffer.concat([
+    Buffer.from([tag]),
+    encodeLength(content.length),
+    content,
+  ]);
+}
+
+export function sequence(...values: Buffer[]): Buffer {
+  return encodeTlv(0x30, Buffer.concat(values));
+}
+
+export function setOfContent(...values: Buffer[]): Buffer {
+  const sorted = values.map(value => Buffer.from(value));
+  sorted.sort((a, b) => Buffer.compare(a, b));
+  return Buffer.concat(sorted);
+}
+
+export function setOf(...values: Buffer[]): Buffer {
+  return encodeTlv(0x31, setOfContent(...values));
+}
+
+export function contextSpecificConstructed(
+  tagNumber: number,
+  content: Buffer,
+): Buffer {
+  if (!Number.isInteger(tagNumber) || tagNumber < 0 || tagNumber > 30)
+    throw new RangeError(`Unsupported context-specific tag: ${tagNumber}`);
+
+  return encodeTlv(0xa0 | tagNumber, content);
+}
+
+export function objectIdentifier(value: string): Buffer {
+  const parts = value.split('.');
+  if (parts.length < 2) throw new Error(`Invalid object identifier: ${value}`);
+
+  const arcs = parts.map(part => {
+    if (!/^(0|[1-9]\d*)$/.test(part))
+      throw new Error(`Invalid object identifier: ${value}`);
+    return BigInt(part);
+  });
+
+  const first = arcs[0];
+  const second = arcs[1];
+  if (
+    first === undefined ||
+    second === undefined ||
+    first > 2n ||
+    (first < 2n && second > 39n)
+  )
+    throw new Error(`Invalid object identifier: ${value}`);
+
+  const encoded = [
+    ...encodeOidArc(first * 40n + second),
+    ...arcs.slice(2).flatMap(encodeOidArc),
+  ];
+  return encodeTlv(0x06, Buffer.from(encoded));
+}
+
+function encodeOidArc(value: bigint): number[] {
+  if (value < 0n) throw new RangeError('OID arcs must be non-negative');
+  if (value === 0n) return [0];
+
+  const bytes: number[] = [];
+  let remaining = value;
+  while (remaining > 0n) {
+    bytes.unshift(Number(remaining & 0x7fn));
+    remaining >>= 7n;
+  }
+
+  for (let i = 0; i < bytes.length - 1; i += 1) bytes[i]! |= 0x80;
+  return bytes;
+}
+
+export function integer(value: number | bigint): Buffer {
+  const asBigInt = typeof value === 'bigint' ? value : BigInt(value);
+  if (asBigInt < 0n)
+    throw new RangeError('Only non-negative INTEGERs are supported');
+
+  let content: Buffer;
+  if (asBigInt === 0n) {
+    content = Buffer.from([0]);
+  } else {
+    const bytes: number[] = [];
+    let remaining = asBigInt;
+    while (remaining > 0n) {
+      bytes.unshift(Number(remaining & 0xffn));
+      remaining >>= 8n;
+    }
+    if ((bytes[0] ?? 0) & 0x80) bytes.unshift(0);
+    content = Buffer.from(bytes);
+  }
+
+  return encodeTlv(0x02, content);
+}
+
+export function octetString(value: Buffer | Uint8Array): Buffer {
+  return encodeTlv(0x04, rawDer(value));
+}
+
+export function nullValue(): Buffer {
+  return Buffer.from([0x05, 0x00]);
+}
+
+export function utcTime(value: Date): Buffer {
+  const timestamp = value.getTime();
+  if (!Number.isFinite(timestamp)) throw new Error('Invalid UTCTime date');
+
+  const year = value.getUTCFullYear();
+  if (year < 1950 || year > 2049)
+    throw new RangeError(`UTCTime year out of range: ${year}`);
+
+  const encoded =
+    pad2(year % 100) +
+    pad2(value.getUTCMonth() + 1) +
+    pad2(value.getUTCDate()) +
+    pad2(value.getUTCHours()) +
+    pad2(value.getUTCMinutes()) +
+    pad2(value.getUTCSeconds()) +
+    'Z';
+
+  return encodeTlv(0x17, Buffer.from(encoded, 'ascii'));
+}
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, '0');
+}
+
+export function extractCertificateInfo(
+  certificateDer: Buffer | Uint8Array,
+): X509CertificateDerInfo {
+  const der = rawDer(certificateDer);
+
+  try {
+    const certificate = readDerElement(der, 0);
+    expectTag(certificate, 0x30, 'certificate');
+    if (certificate.end !== der.length)
+      throw new Error('certificate has trailing data');
+
+    const tbsCertificate = readDerElement(der, certificate.contentStart);
+    expectTag(tbsCertificate, 0x30, 'tbsCertificate');
+
+    let cursor = tbsCertificate.contentStart;
+    const firstTbsField = readDerElement(der, cursor);
+    if (firstTbsField.tag === 0xa0) {
+      const version = readDerElement(der, firstTbsField.contentStart);
+      expectTag(version, 0x02, 'certificate version');
+      if (version.end !== firstTbsField.end)
+        throw new Error('certificate version field has trailing data');
+      cursor = firstTbsField.end;
+    }
+
+    const serialNumber = readDerElement(der, cursor);
+    expectTag(serialNumber, 0x02, 'certificate serialNumber');
+    cursor = serialNumber.end;
+
+    const signature = readDerElement(der, cursor);
+    expectTag(signature, 0x30, 'certificate signature algorithm');
+    cursor = signature.end;
+
+    const issuer = readDerElement(der, cursor);
+    expectTag(issuer, 0x30, 'certificate issuer');
+
+    return {
+      rawCertificate: Buffer.from(certificate.raw),
+      tbsCertificate: Buffer.from(tbsCertificate.raw),
+      serialNumber: Buffer.from(serialNumber.raw),
+      issuer: Buffer.from(issuer.raw),
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse X.509 certificate DER: ${detail}`, {
+      cause: error,
+    });
+  }
+}
+
+function readDerElement(input: Buffer, offset: number): DerElement {
+  if (!Number.isSafeInteger(offset) || offset < 0 || offset >= input.length)
+    throw new Error(`element offset ${offset} is outside input`);
+
+  const tag = input[offset];
+  if (tag === undefined) throw new Error(`missing tag at offset ${offset}`);
+  if ((tag & 0x1f) === 0x1f)
+    throw new Error(`high-tag-number form is unsupported at offset ${offset}`);
+
+  const firstLength = input[offset + 1];
+  if (firstLength === undefined)
+    throw new Error(`missing length at offset ${offset}`);
+
+  let contentStart = offset + 2;
+  let length: number;
+  if ((firstLength & 0x80) === 0) {
+    length = firstLength;
+  } else {
+    const lengthOctets = firstLength & 0x7f;
+    if (lengthOctets === 0) throw new Error('indefinite lengths are not DER');
+    if (lengthOctets > 6) throw new Error('DER length is too large');
+    if (contentStart + lengthOctets > input.length)
+      throw new Error(`truncated length at offset ${offset}`);
+    if (input[contentStart] === 0)
+      throw new Error(`non-minimal length at offset ${offset}`);
+
+    length = 0;
+    for (let i = 0; i < lengthOctets; i += 1)
+      length = length * 0x100 + input[contentStart + i]!;
+    if (length < 0x80)
+      throw new Error(`non-minimal length at offset ${offset}`);
+    contentStart += lengthOctets;
+  }
+
+  const end = contentStart + length;
+  if (end > input.length)
+    throw new Error(`element overruns input at offset ${offset}`);
+
+  return {
+    tag,
+    contentStart,
+    end,
+    raw: input.subarray(offset, end),
+  };
+}
+
+function expectTag(element: DerElement, expected: number, label: string): void {
+  if (element.tag !== expected)
+    throw new Error(
+      `${label} has tag 0x${element.tag.toString(16)}, expected 0x${expected.toString(16)}`,
+    );
+}

--- a/src/lib/sign-manifest.ts
+++ b/src/lib/sign-manifest.ts
@@ -9,29 +9,37 @@ import {
 } from 'node:crypto';
 import type { KeyObject } from 'node:crypto';
 
-import * as asn1js from 'asn1js';
 import {
-  Certificate as PkiCertificate,
-  ContentInfo,
-  EncapsulatedContentInfo,
-  IssuerAndSerialNumber,
-  SignedData,
-  SignerInfo,
-  SignedAndUnsignedAttributes,
-  Attribute,
-  AlgorithmIdentifier,
-} from 'pkijs';
+  contextSpecificConstructed,
+  extractCertificateInfo,
+  integer,
+  nullValue,
+  objectIdentifier,
+  octetString,
+  sequence,
+  setOf,
+  setOfContent,
+  utcTime,
+} from './der.js';
+import type { X509CertificateDerInfo } from './der.js';
 
-// Convert a PEM certificate into a pkijs Certificate by going through the
-// node:crypto X509Certificate parser (which accepts PEM and emits DER in .raw).
-function parsePkiCertificate(pem: string): PkiCertificate {
-  const der = new X509Certificate(pem).raw;
-  const ab = der.buffer.slice(der.byteOffset, der.byteOffset + der.byteLength);
-  const asn1 = asn1js.fromBER(ab);
-  if (asn1.offset === -1) {
-    throw new Error('Failed to parse X.509 certificate: invalid ASN.1');
-  }
-  return new PkiCertificate({ schema: asn1.result });
+interface CmsCertificate extends X509CertificateDerInfo {
+  notAfter: Date;
+}
+
+function parseCertificate(pem: string): CmsCertificate {
+  const certificate = new X509Certificate(pem);
+  return {
+    ...extractCertificateInfo(certificate.raw),
+    notAfter: parseX509Date(certificate.validTo),
+  };
+}
+
+function parseX509Date(value: string): Date {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp))
+    throw new Error(`Failed to parse X.509 certificate expiry: ${value}`);
+  return new Date(timestamp);
 }
 
 // Apple WWDR Certification Authority — G4
@@ -74,10 +82,11 @@ const OID_CONTENT_TYPE = '1.2.840.113549.1.9.3';
 const OID_MESSAGE_DIGEST = '1.2.840.113549.1.9.4';
 const OID_SIGNING_TIME = '1.2.840.113549.1.9.5';
 const OID_DATA = '1.2.840.113549.1.7.1';
+const OID_SIGNED_DATA = '1.2.840.113549.1.7.2';
 const OID_SHA1 = '1.3.14.3.2.26';
 const OID_RSA_ENCRYPTION = '1.2.840.113549.1.1.1';
 
-const APPLE_WWDR_CA = parsePkiCertificate(APPLE_WWDR_CA_PEM);
+const APPLE_WWDR_CA = parseCertificate(APPLE_WWDR_CA_PEM);
 
 // Emit a process warning if the bundled WWDR cert is within 90 days of
 // expiry (or already expired). The 2013–2023 G1 silently expired and every
@@ -89,7 +98,7 @@ const APPLE_WWDR_CA = parsePkiCertificate(APPLE_WWDR_CA_PEM);
 //   node --disable-warning=WalletPassWWDRExpiring app.js
 //   process.on('warning', w => { if (w.code === 'WALLETPASS_WWDR_EXPIRED') ... })
 const WWDR_WARN_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
-const wwdrNotAfter = APPLE_WWDR_CA.notAfter.value;
+const wwdrNotAfter = APPLE_WWDR_CA.notAfter;
 const msUntilExpiry = wwdrNotAfter.getTime() - Date.now();
 if (msUntilExpiry < WWDR_WARN_WINDOW_MS) {
   const when = wwdrNotAfter.toISOString().slice(0, 10);
@@ -123,7 +132,7 @@ export function signManifest(
   privateKey: string | KeyObject,
   manifestJson: string,
 ): Buffer {
-  const signerCert = parsePkiCertificate(certificatePem);
+  const signerCert = parseCertificate(certificatePem);
 
   const keyObject =
     typeof privateKey === 'string' ? createPrivateKey(privateKey) : privateKey;
@@ -131,68 +140,52 @@ export function signManifest(
   const manifestBytes = Buffer.from(manifestJson, 'utf8');
   const digest = createHash('sha1').update(manifestBytes).digest();
 
-  // Authenticated attributes: content-type, message-digest, signing-time.
-  // These are what Apple requires in the SignerInfo.
-  const signedAttrs = new SignedAndUnsignedAttributes({
-    type: 0,
-    attributes: [
-      new Attribute({
-        type: OID_CONTENT_TYPE,
-        values: [new asn1js.ObjectIdentifier({ value: OID_DATA })],
-      }),
-      new Attribute({
-        type: OID_MESSAGE_DIGEST,
-        values: [new asn1js.OctetString({ valueHex: digest })],
-      }),
-      new Attribute({
-        type: OID_SIGNING_TIME,
-        values: [new asn1js.UTCTime({ valueDate: new Date() })],
-      }),
-    ],
-  });
+  const signedAttributes = [
+    cmsAttribute(OID_CONTENT_TYPE, objectIdentifier(OID_DATA)),
+    cmsAttribute(OID_MESSAGE_DIGEST, octetString(digest)),
+    cmsAttribute(OID_SIGNING_TIME, utcTime(new Date())),
+  ];
+  const signedAttributesContent = setOfContent(...signedAttributes);
+  const signedAttributesDer = setOf(...signedAttributes);
 
-  const signerInfo = new SignerInfo({
-    version: 1,
-    sid: new IssuerAndSerialNumber({
-      issuer: signerCert.issuer,
-      serialNumber: signerCert.serialNumber,
-    }),
-    digestAlgorithm: new AlgorithmIdentifier({ algorithmId: OID_SHA1 }),
-    signedAttrs,
-    signatureAlgorithm: new AlgorithmIdentifier({
-      algorithmId: OID_RSA_ENCRYPTION,
-    }),
-  });
+  // CMS signs the DER SET OF attributes, while SignerInfo stores the same
+  // content under the IMPLICIT [0] signedAttrs tag.
+  const signature = createSign('sha1')
+    .update(signedAttributesDer)
+    .sign(keyObject);
 
-  // Serialize the signed attributes (SET OF), sign with RSA-SHA1.
-  // Per RFC 5652 §5.4, the IMPLICIT [0] is replaced with an explicit SET tag
-  // for the signed bytes.
-  const attrsDer = Buffer.from(
-    (signedAttrs.toSchema() as asn1js.Constructed).toBER(false),
+  const signerInfo = sequence(
+    integer(1),
+    sequence(signerCert.issuer, signerCert.serialNumber),
+    algorithmIdentifier(OID_SHA1),
+    contextSpecificConstructed(0, signedAttributesContent),
+    algorithmIdentifier(OID_RSA_ENCRYPTION, nullValue()),
+    octetString(signature),
   );
-  // Replace the IMPLICIT [0] tag (0xA0) with explicit SET (0x31).
-  const toSign = Buffer.concat([Buffer.from([0x31]), attrsDer.subarray(1)]);
 
-  const signature = createSign('sha1').update(toSign).sign(keyObject);
-  signerInfo.signature = new asn1js.OctetString({ valueHex: signature });
+  const signedData = sequence(
+    integer(1),
+    setOf(algorithmIdentifier(OID_SHA1)),
+    sequence(objectIdentifier(OID_DATA)),
+    contextSpecificConstructed(
+      0,
+      setOfContent(signerCert.rawCertificate, APPLE_WWDR_CA.rawCertificate),
+    ),
+    setOf(signerInfo),
+  );
 
-  const signedData = new SignedData({
-    version: 1,
-    digestAlgorithms: [new AlgorithmIdentifier({ algorithmId: OID_SHA1 })],
-    encapContentInfo: new EncapsulatedContentInfo({
-      eContentType: OID_DATA,
-      // No eContent — detached signature.
-    }),
-    certificates: [signerCert, APPLE_WWDR_CA],
-    signerInfos: [signerInfo],
-  });
+  return sequence(
+    objectIdentifier(OID_SIGNED_DATA),
+    contextSpecificConstructed(0, signedData),
+  );
+}
 
-  // Wrap in ContentInfo.
-  const contentInfo = new ContentInfo({
-    contentType: '1.2.840.113549.1.7.2', // id-signedData
-    content: signedData.toSchema(true),
-  });
+function algorithmIdentifier(oid: string, parameters?: Buffer): Buffer {
+  const parts = [objectIdentifier(oid)];
+  if (parameters !== undefined) parts.push(parameters);
+  return sequence(...parts);
+}
 
-  const ber = contentInfo.toSchema().toBER(false);
-  return Buffer.from(ber);
+function cmsAttribute(type: string, ...values: Buffer[]): Buffer {
+  return sequence(objectIdentifier(type), setOf(...values));
 }


### PR DESCRIPTION
## Summary

Replaces the `pkijs`-based PKCS#7/CMS signing path with a narrow in-repo DER/CMS writer for the detached SignedData shape emitted by pass-js.

## What changed

- Added minimal DER helpers for lengths, sequences, sets, OIDs, integers, octet strings, UTCTime, NULL, context-specific wrappers, and raw X.509 passthrough.
- Added X.509 DER extraction for the signer certificate issuer, serial number, TBS certificate, and full certificate DER.
- Refactored `signManifest` to build CMS `ContentInfo -> SignedData -> SignerInfo` directly and sign DER signed attributes with `node:crypto`.
- Removed `pkijs` and its transitive runtime dependency chain from package metadata.
- Strengthened DER, X.509, OpenSSL CMS verification, and ASN.1 shape tests.
- Simplified the CI esbuild bundle smoke by removing the CommonJS `createRequire` banner shim that existed for `pkijs` transitive CJS dependencies.
- Updated maintainer docs to describe the in-repo CMS writer and the desired future replacement with native Node CMS support if it appears.

## Impact

Public APIs stay unchanged. The library still emits Apple-required SHA-1 manifest hashes and RSA-SHA1 detached CMS signatures, embeds the signer cert plus bundled WWDR cert, and continues to verify with OpenSSL.

The esbuild single-file bundle no longer needs the injected CommonJS shim because the `pkijs` dependency chain is gone.

## Validation

- `npm run build`
- `npm run lint`
- `npm test` (118 passed, 1 skipped)
- Simplified esbuild smoke:
  - `npx esbuild dist/index.js --bundle --platform=node --format=esm --target=node24 --outfile=/tmp/bundle.mjs`
  - imported `/tmp/bundle.mjs` from outside the repo and verified `Pass` and `Template` exports
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an external PKI dependency
  * Adjusted bundling configuration

* **Tests**
  * Added comprehensive tests for DER and X.509 handling
  * Strengthened manifest signing validation with deeper PKCS#7 checks

* **Documentation**
  * Updated docs to reflect the new in-repo signing implementation and maintenance notes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinovyatkin/pass-js/pull/666)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->