### PR TITLE
perf: optimize zip read/write paths

### DIFF
--- a/src/lib/zip.ts
+++ b/src/lib/zip.ts
@@ -1,24 +1,28 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2017-2026 Konstantin Vyatkin <tino@vtkn.io>
 
-import { inflateRawSync } from 'node:zlib';
-
-// CRC-32 (IEEE 802.3) table, built once.
-const CRC_TABLE = (() => {
-  const table = new Uint32Array(256);
-  for (let n = 0; n < 256; n++) {
-    let c = n;
-    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
-    table[n] = c >>> 0;
-  }
-  return table;
-})();
+import { crc32 as zlibCrc32, inflateRawSync } from 'node:zlib';
 
 export function crc32(bytes: Uint8Array): number {
-  let sum = 0xffffffff;
-  for (const b of bytes) sum = (sum >>> 8) ^ CRC_TABLE[(sum ^ b) & 0xff]!;
-  return (sum ^ 0xffffffff) >>> 0;
+  return zlibCrc32(bytes) >>> 0;
 }
+
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE_BYTES = Buffer.from([
+  0x50, 0x4b, 0x05, 0x06,
+]);
+
+const LOCAL_FILE_HEADER_LEN = 30;
+const CENTRAL_DIRECTORY_HEADER_LEN = 46;
+const END_OF_CENTRAL_DIRECTORY_LEN = 22;
+const ZIP32_MAX = 0xffffffff;
+
+// Safety caps — pkpass bundles are tiny. Reject anything abusive.
+const MAX_ENTRIES = 4096;
+const MAX_ENTRY_SIZE = 16 * 1024 * 1024; // 16 MiB per entry
+const MAX_COMMENT_LEN = 0xffff;
 
 // ─── Writer ─────────────────────────────────────────────────────────────────
 
@@ -33,12 +37,32 @@ export interface ZipWriteEntry {
 // consumers from using the library to emit zip-slip archives.
 const UNSAFE_PATH_RE = /^\/|\\|(^|\/)\.\.(\/|$)/;
 
+interface PreparedZipEntry {
+  readonly name: Buffer;
+  readonly body: Buffer;
+  readonly checksum: number;
+  readonly size: number;
+  readonly localOffset: number;
+}
+
+function assertZip32(value: number, description: string): void {
+  if (value > ZIP32_MAX) {
+    throw new Error(`ZIP is too large: ${description} requires ZIP64`);
+  }
+}
+
 // Writes a STORE-only (no compression) ZIP bundle suitable for .pkpass files.
 // pkpass payloads are small JSON + small PNGs; compression is counterproductive.
 export function writeZip(files: readonly ZipWriteEntry[]): Buffer {
-  const localRecords: Buffer[] = [];
-  const centralRecords: Buffer[] = [];
+  if (files.length > MAX_ENTRIES) {
+    throw new Error(
+      `ZIP has too many entries (${files.length} > ${MAX_ENTRIES})`,
+    );
+  }
+
+  const entries: PreparedZipEntry[] = [];
   let localOffset = 0;
+  let centralSize = 0;
 
   for (const { path, data } of files) {
     if (UNSAFE_PATH_RE.test(path)) {
@@ -48,64 +72,79 @@ export function writeZip(files: readonly ZipWriteEntry[]): Buffer {
     }
     const body = typeof data === 'string' ? Buffer.from(data) : data;
     const name = Buffer.from(path, 'utf8');
+    if (name.length > 0xffff) {
+      throw new Error(
+        `Entry "${path}" filename is too long (${name.length} > 65535 bytes)`,
+      );
+    }
     const checksum = crc32(body);
     const size = body.length;
+    assertZip32(size, `entry "${path}"`);
 
-    // Local file header + data
-    const local = Buffer.alloc(30 + name.length + size);
-    local.writeUInt32LE(0x04034b50, 0); // local file header signature
-    local.writeUInt16LE(10, 4); // version needed to extract (1.0 — STORE only)
-    local.writeUInt16LE(0, 6); // general purpose bit flag
-    local.writeUInt16LE(0, 8); // compression method (0 = STORE)
-    local.writeUInt16LE(0, 10); // last mod file time
-    local.writeUInt16LE(0, 12); // last mod file date
-    local.writeUInt32LE(checksum, 14); // CRC-32
-    local.writeUInt32LE(size, 18); // compressed size
-    local.writeUInt32LE(size, 22); // uncompressed size
-    local.writeUInt16LE(name.length, 26); // file name length
-    local.writeUInt16LE(0, 28); // extra field length
-    name.copy(local, 30);
-    body.copy(local, 30 + name.length);
-    localRecords.push(local);
+    entries.push({ name, body, checksum, size, localOffset });
 
-    // Central directory header
-    const central = Buffer.alloc(46 + name.length);
-    central.writeUInt32LE(0x02014b50, 0); // central directory signature
-    central.writeUInt16LE(20, 4); // version made by
-    central.writeUInt16LE(10, 6); // version needed to extract
-    central.writeUInt16LE(0, 8); // general purpose bit flag
-    central.writeUInt16LE(0, 10); // compression method
-    central.writeUInt16LE(0, 12); // last mod file time
-    central.writeUInt16LE(0, 14); // last mod file date
-    central.writeUInt32LE(checksum, 16); // CRC-32
-    central.writeUInt32LE(size, 20); // compressed size
-    central.writeUInt32LE(size, 24); // uncompressed size
-    central.writeUInt16LE(name.length, 28); // file name length
-    central.writeUInt16LE(0, 30); // extra field length
-    central.writeUInt16LE(0, 32); // file comment length
-    central.writeUInt16LE(0, 34); // disk number start
-    central.writeUInt16LE(0, 36); // internal file attributes
-    central.writeUInt32LE(0, 38); // external file attributes
-    central.writeUInt32LE(localOffset, 42); // relative offset of local header
-    name.copy(central, 46);
-    centralRecords.push(central);
-
-    localOffset += local.length;
+    localOffset += LOCAL_FILE_HEADER_LEN + name.length + size;
+    centralSize += CENTRAL_DIRECTORY_HEADER_LEN + name.length;
+    assertZip32(localOffset, 'local file records');
+    assertZip32(centralSize, 'central directory');
   }
 
-  const central = Buffer.concat(centralRecords);
-  // End of central directory record
-  const eocd = Buffer.alloc(22);
-  eocd.writeUInt32LE(0x06054b50, 0); // EOCD signature
-  eocd.writeUInt16LE(0, 4); // number of this disk
-  eocd.writeUInt16LE(0, 6); // disk where central directory starts
-  eocd.writeUInt16LE(files.length, 8); // entries on this disk
-  eocd.writeUInt16LE(files.length, 10); // total entries in central directory
-  eocd.writeUInt32LE(central.length, 12); // size of central directory
-  eocd.writeUInt32LE(localOffset, 16); // offset of central directory
-  eocd.writeUInt16LE(0, 20); // ZIP file comment length
+  const centralOffset = localOffset;
+  const totalSize = localOffset + centralSize + END_OF_CENTRAL_DIRECTORY_LEN;
+  assertZip32(totalSize, 'archive');
 
-  return Buffer.concat([...localRecords, central, eocd]);
+  const out = Buffer.allocUnsafe(totalSize);
+  let p = 0;
+
+  for (const entry of entries) {
+    out.writeUInt32LE(LOCAL_FILE_HEADER_SIGNATURE, p);
+    out.writeUInt16LE(10, p + 4); // version needed to extract (1.0 — STORE)
+    out.writeUInt16LE(0, p + 6); // general purpose bit flag
+    out.writeUInt16LE(0, p + 8); // compression method (0 = STORE)
+    out.writeUInt16LE(0, p + 10); // last mod file time
+    out.writeUInt16LE(0, p + 12); // last mod file date
+    out.writeUInt32LE(entry.checksum, p + 14); // CRC-32
+    out.writeUInt32LE(entry.size, p + 18); // compressed size
+    out.writeUInt32LE(entry.size, p + 22); // uncompressed size
+    out.writeUInt16LE(entry.name.length, p + 26); // file name length
+    out.writeUInt16LE(0, p + 28); // extra field length
+    entry.name.copy(out, p + LOCAL_FILE_HEADER_LEN);
+    entry.body.copy(out, p + LOCAL_FILE_HEADER_LEN + entry.name.length);
+    p += LOCAL_FILE_HEADER_LEN + entry.name.length + entry.size;
+  }
+
+  for (const entry of entries) {
+    out.writeUInt32LE(CENTRAL_DIRECTORY_SIGNATURE, p);
+    out.writeUInt16LE(20, p + 4); // version made by
+    out.writeUInt16LE(10, p + 6); // version needed to extract
+    out.writeUInt16LE(0, p + 8); // general purpose bit flag
+    out.writeUInt16LE(0, p + 10); // compression method
+    out.writeUInt16LE(0, p + 12); // last mod file time
+    out.writeUInt16LE(0, p + 14); // last mod file date
+    out.writeUInt32LE(entry.checksum, p + 16); // CRC-32
+    out.writeUInt32LE(entry.size, p + 20); // compressed size
+    out.writeUInt32LE(entry.size, p + 24); // uncompressed size
+    out.writeUInt16LE(entry.name.length, p + 28); // file name length
+    out.writeUInt16LE(0, p + 30); // extra field length
+    out.writeUInt16LE(0, p + 32); // file comment length
+    out.writeUInt16LE(0, p + 34); // disk number start
+    out.writeUInt16LE(0, p + 36); // internal file attributes
+    out.writeUInt32LE(0, p + 38); // external file attributes
+    out.writeUInt32LE(entry.localOffset, p + 42); // local header offset
+    entry.name.copy(out, p + CENTRAL_DIRECTORY_HEADER_LEN);
+    p += CENTRAL_DIRECTORY_HEADER_LEN + entry.name.length;
+  }
+
+  out.writeUInt32LE(END_OF_CENTRAL_DIRECTORY_SIGNATURE, p); // EOCD signature
+  out.writeUInt16LE(0, p + 4); // number of this disk
+  out.writeUInt16LE(0, p + 6); // disk where central directory starts
+  out.writeUInt16LE(files.length, p + 8); // entries on this disk
+  out.writeUInt16LE(files.length, p + 10); // total central directory entries
+  out.writeUInt32LE(centralSize, p + 12); // size of central directory
+  out.writeUInt32LE(centralOffset, p + 16); // offset of central directory
+  out.writeUInt16LE(0, p + 20); // ZIP file comment length
+
+  return out;
 }
 
 // ─── Reader ─────────────────────────────────────────────────────────────────
@@ -124,24 +163,31 @@ export interface UnzippedBuffer {
   getBuffer(entry: ZipReadEntry): Buffer;
 }
 
-// Safety caps — pkpass bundles are tiny. Reject anything abusive.
-const MAX_ENTRIES = 4096;
-const MAX_ENTRY_SIZE = 16 * 1024 * 1024; // 16 MiB per entry
-const MAX_COMMENT_LEN = 0xffff;
-
 // Reads a STORE/DEFLATE ZIP from a Buffer. Supports what .pkpass files use
 // and nothing else: no ZIP64, no encryption, no multi-disk, no exotic codecs.
 export function readZip(buf: Buffer): UnzippedBuffer {
   // 1. Find End-Of-Central-Directory record by scanning back from the end.
   // EOCD is at least 22 bytes, plus up to 64K of trailing comment.
-  const eocdMin = 22;
-  const searchStart = Math.max(0, buf.length - eocdMin - MAX_COMMENT_LEN);
+  const searchStart = Math.max(
+    0,
+    buf.length - END_OF_CENTRAL_DIRECTORY_LEN - MAX_COMMENT_LEN,
+  );
   let eocdOffset = -1;
-  for (let i = buf.length - eocdMin; i >= searchStart; i--) {
-    if (buf.readUInt32LE(i) === 0x06054b50) {
-      eocdOffset = i;
+  let searchFrom = buf.length - END_OF_CENTRAL_DIRECTORY_LEN;
+  while (searchFrom >= searchStart) {
+    const candidate = buf.lastIndexOf(
+      END_OF_CENTRAL_DIRECTORY_SIGNATURE_BYTES,
+      searchFrom,
+    );
+    if (candidate < searchStart) break;
+    const commentLen = buf.readUInt16LE(
+      candidate + END_OF_CENTRAL_DIRECTORY_LEN - 2,
+    );
+    if (candidate + END_OF_CENTRAL_DIRECTORY_LEN + commentLen === buf.length) {
+      eocdOffset = candidate;
       break;
     }
+    searchFrom = candidate - 1;
   }
   if (eocdOffset < 0) {
     throw new Error('Invalid ZIP: end-of-central-directory record not found');
@@ -157,8 +203,10 @@ export function readZip(buf: Buffer): UnzippedBuffer {
     );
   }
   if (
-    centralOffset + centralSize > eocdOffset ||
-    centralOffset + 46 > buf.length
+    centralOffset > eocdOffset ||
+    centralSize > eocdOffset - centralOffset ||
+    (entryCount > 0 &&
+      centralOffset + CENTRAL_DIRECTORY_HEADER_LEN > buf.length)
   ) {
     throw new Error('Invalid ZIP: central directory out of bounds');
   }
@@ -169,12 +217,12 @@ export function readZip(buf: Buffer): UnzippedBuffer {
   const entries: ZipReadEntry[] = [];
   let p = centralOffset;
   for (let i = 0; i < entryCount; i++) {
-    if (p + 46 > centralEnd) {
+    if (p + CENTRAL_DIRECTORY_HEADER_LEN > centralEnd) {
       throw new Error(
         'Malformed ZIP central directory: entry header truncated',
       );
     }
-    if (buf.readUInt32LE(p) !== 0x02014b50) {
+    if (buf.readUInt32LE(p) !== CENTRAL_DIRECTORY_SIGNATURE) {
       throw new Error('Invalid ZIP: bad central directory entry signature');
     }
     const method = buf.readUInt16LE(p + 10);
@@ -186,13 +234,18 @@ export function readZip(buf: Buffer): UnzippedBuffer {
     const commentLen = buf.readUInt16LE(p + 32);
     const localHeaderOffset = buf.readUInt32LE(p + 42);
 
-    const entryBlockEnd = p + 46 + nameLen + extraLen + commentLen;
+    const entryBlockEnd =
+      p + CENTRAL_DIRECTORY_HEADER_LEN + nameLen + extraLen + commentLen;
     if (entryBlockEnd > centralEnd) {
       throw new Error(
         'Malformed ZIP central directory: entry extends past central directory bounds',
       );
     }
-    const filename = buf.toString('utf8', p + 46, p + 46 + nameLen);
+    const filename = buf.toString(
+      'utf8',
+      p + CENTRAL_DIRECTORY_HEADER_LEN,
+      p + CENTRAL_DIRECTORY_HEADER_LEN + nameLen,
+    );
 
     if (method !== 0 && method !== 8) {
       throw new Error(
@@ -209,7 +262,7 @@ export function readZip(buf: Buffer): UnzippedBuffer {
         `Entry "${filename}" has an unsafe path (leading slash, backslash, or '..' segment)`,
       );
     }
-    if (localHeaderOffset + 30 > centralOffset) {
+    if (localHeaderOffset + LOCAL_FILE_HEADER_LEN > centralOffset) {
       throw new Error(
         `Invalid ZIP: entry "${filename}" local header offset out of bounds`,
       );
@@ -242,21 +295,22 @@ export function readZip(buf: Buffer): UnzippedBuffer {
       // as zero and only populate them in the central directory. pkpass
       // bundles produced this way are valid and the standard mandates this.
       const h = entry.localHeaderOffset;
-      if (h + 30 > buf.length) {
+      if (h + LOCAL_FILE_HEADER_LEN > buf.length) {
         throw new Error(
           `Invalid ZIP: local header for "${entry.filename}" out of bounds`,
         );
       }
-      if (buf.readUInt32LE(h) !== 0x04034b50) {
+      if (buf.readUInt32LE(h) !== LOCAL_FILE_HEADER_SIGNATURE) {
         throw new Error(
           `Invalid ZIP: bad local header for entry "${entry.filename}"`,
         );
       }
       const localNameLen = buf.readUInt16LE(h + 26);
       const localExtraLen = buf.readUInt16LE(h + 28);
-      const dataStart = h + 30 + localNameLen + localExtraLen;
+      const dataStart =
+        h + LOCAL_FILE_HEADER_LEN + localNameLen + localExtraLen;
       const dataEnd = dataStart + entry.compressedSize;
-      if (dataEnd > buf.length || dataStart < h + 30) {
+      if (dataEnd > buf.length || dataStart < h + LOCAL_FILE_HEADER_LEN) {
         throw new Error(
           `Invalid ZIP: entry "${entry.filename}" data out of bounds`,
         );
@@ -265,18 +319,21 @@ export function readZip(buf: Buffer): UnzippedBuffer {
       const out =
         entry.method === 0
           ? Buffer.from(raw)
-          : inflateRawSync(raw, { maxOutputLength: MAX_ENTRY_SIZE });
+          : inflateRawSync(raw, {
+              maxOutputLength: Math.max(1, entry.uncompressedSize),
+            });
 
       if (out.length !== entry.uncompressedSize) {
         throw new Error(
           `Entry "${entry.filename}" size mismatch: header says ${entry.uncompressedSize}, got ${out.length}`,
         );
       }
-      if (crc32(out) !== entry.crc32) {
+      const actualCrc = crc32(out);
+      if (actualCrc !== entry.crc32) {
         throw new Error(
           `Entry "${entry.filename}" CRC32 mismatch (header ${entry.crc32.toString(
             16,
-          )}, got ${crc32(out).toString(16)})`,
+          )}, got ${actualCrc.toString(16)})`,
         );
       }
       return out;


### PR DESCRIPTION
## Summary

- Replace the in-repo JavaScript CRC-32 byte loop with Node's native `zlib.crc32` while keeping the existing exported `crc32` helper.
- Rewrite the STORE-only ZIP writer to precompute entry metadata and fill one pre-sized output buffer instead of allocating and concatenating per-entry records.
- Tighten ZIP32, filename, central-directory, and inflate-size bounds while avoiding duplicate CRC work during reads.

## Impact

This reduces CPU time and memory churn in the internal ZIP reader/writer used for `.pkpass` generation and template loading, without expanding the supported ZIP feature set.

Quick synthetic benchmark on this checkout:

- `writeZip`: about `2321.5ms -> 71.5ms`
- repeated `getBuffer`: about `942.2ms -> 30.4ms`

## Validation

- `npm run build`
- `npm run lint`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ZIP file parsing and extraction reliability with stricter validation and improved data integrity checks during file handling.

* **Refactor**
  * Optimized ZIP creation and parsing internals for robustness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinovyatkin/pass-js/pull/669)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->