### PR TITLE
feat: add pass personalization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,32 @@ await template.images.load('./images');
 
 Image input may be a file path or a `Buffer`. Format is enforced: only **PNG** is accepted.
 
+For NFC reward-card signup flows, add PassKit personalization metadata and a
+150 x 40 point personalization logo:
+
+```js
+const template = new Template('storeCard', {
+  passTypeIdentifier: 'pass.com.example.passbook',
+  teamIdentifier: 'MXL',
+});
+
+template.nfc.message = 'member-id';
+template.personalization = {
+  description: 'Join Acme Rewards',
+  requiredPersonalizationFields: [
+    'PKPassPersonalizationFieldName',
+    'PKPassPersonalizationFieldEmailAddress',
+  ],
+  termsAndConditions: '<a href="https://example.com/terms">Terms</a>',
+};
+await template.images.add('personalizationLogo', personalizationLogoPng);
+```
+
+`personalization.json` and `personalizationLogo*.png` are emitted only when
+the final pass has NFC data, personalization metadata, and at least one
+personalization logo. If any piece is missing, the personalization files are
+left out of the generated bundle.
+
 If you have a single directory that contains `pass.json`, the key
 `com.example.passbook.pem`, and all the images you need, one call does everything:
 

--- a/__tests__/images.ts
+++ b/__tests__/images.ts
@@ -14,6 +14,7 @@ describe('PassImages', () => {
     assert.doesNotMatch('byakablogo.png', IMAGE_FILENAME_REGEX);
     assert.match('icon@2x.png', IMAGE_FILENAME_REGEX);
     assert.match('thumbnail@3x.png', IMAGE_FILENAME_REGEX);
+    assert.match('personalizationLogo@3x.png', IMAGE_FILENAME_REGEX);
     assert.doesNotMatch('logo@4x', IMAGE_FILENAME_REGEX);
     assert.doesNotMatch('byaka.png', IMAGE_FILENAME_REGEX);
     assert.doesNotMatch('logo.jpg', IMAGE_FILENAME_REGEX);
@@ -25,6 +26,10 @@ describe('PassImages', () => {
     assert.deepEqual(img.parseFilename('icon@2x.png'), {
       imageType: 'icon',
       density: '2x',
+    });
+    assert.deepEqual(img.parseFilename('personalizationLogo@3x.png'), {
+      imageType: 'personalizationLogo',
+      density: '3x',
     });
     assert.equal(img.parseFilename('logo.jpg'), undefined);
   });
@@ -60,6 +65,24 @@ describe('PassImages', () => {
       img.add('icon', tinyPng, undefined, undefined, true),
     );
     assert.equal(img.size, 1);
+  });
+
+  it('validates personalizationLogo dimensions', async () => {
+    const img = new PassImages();
+    await assert.doesNotReject(() =>
+      img.add(
+        'personalizationLogo',
+        path.resolve(__dirname, './resources/logo.png'),
+      ),
+    );
+    await assert.rejects(
+      () =>
+        img.add(
+          'personalizationLogo',
+          path.resolve(__dirname, '../images/logo.png'),
+        ),
+      /personalizationLogo image must have width no larger than 150px/,
+    );
   });
 
   it('reads localized images', async t => {

--- a/__tests__/personalization.ts
+++ b/__tests__/personalization.ts
@@ -1,6 +1,6 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
@@ -40,9 +40,23 @@ function makeTestKeypair(): { certPem: string; keyPem: string } {
   const dir = mkdtempSync(`${tmpdir()}${path.sep}`);
   const keyPath = path.join(dir, 't.key');
   const certPath = path.join(dir, 't.crt');
-  execSync(
-    `openssl req -x509 -newkey rsa:2048 -keyout ${keyPath} -out ${certPath} ` +
-      `-days 1 -nodes -subj "/CN=Pass Type ID: pass.com.example.passbook/O=pass-js test"`,
+  execFileSync(
+    'openssl',
+    [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-keyout',
+      keyPath,
+      '-out',
+      certPath,
+      '-days',
+      '1',
+      '-nodes',
+      '-subj',
+      '/CN=Pass Type ID: pass.com.example.passbook/O=pass-js test',
+    ],
     { stdio: 'ignore' },
   );
   return {
@@ -134,6 +148,14 @@ describe('personalization', () => {
           pass.personalization = personalization;
         },
       },
+      {
+        name: 'empty nfc message',
+        async setup(pass) {
+          pass.nfc.message = '';
+          pass.personalization = personalization;
+          await pass.images.add('personalizationLogo', logo);
+        },
+      },
     ];
 
     for (const testCase of cases) {
@@ -214,5 +236,11 @@ describe('personalization', () => {
         requiredPersonalizationFields: ['not-a-field'],
       } as unknown as Personalization;
     }, /requiredPersonalizationFields\[0\] is invalid/);
+    assert.throws(() => {
+      template.personalization = {
+        description: 'Join',
+        requiredPersonalizationFields: [],
+      };
+    }, /requiredPersonalizationFields must contain at least one field/);
   });
 });

--- a/__tests__/personalization.ts
+++ b/__tests__/personalization.ts
@@ -1,0 +1,218 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Template } from '../dist/template.js';
+import { readZip, writeZip } from '../dist/lib/zip.js';
+import type { Pass } from '../dist/pass.js';
+import type { Personalization } from '../dist/index.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const icon = readFileSync(path.resolve(__dirname, './resources/icon.png'));
+const logo = readFileSync(path.resolve(__dirname, './resources/logo.png'));
+
+const baseFields = {
+  passTypeIdentifier: 'pass.com.example.passbook',
+  teamIdentifier: 'MXL',
+  serialNumber: 'personalization-1',
+  organizationName: 'Acme rewards',
+  description: 'Acme rewards signup',
+};
+
+const personalization: Personalization = {
+  description: 'Join Acme Rewards',
+  requiredPersonalizationFields: [
+    'PKPassPersonalizationFieldName',
+    'PKPassPersonalizationFieldEmailAddress',
+  ],
+  termsAndConditions: '<a href="https://example.com/terms">Terms</a>',
+};
+
+let certPem: string;
+let keyPem: string;
+
+function makeTestKeypair(): { certPem: string; keyPem: string } {
+  const dir = mkdtempSync(`${tmpdir()}${path.sep}`);
+  const keyPath = path.join(dir, 't.key');
+  const certPath = path.join(dir, 't.crt');
+  execSync(
+    `openssl req -x509 -newkey rsa:2048 -keyout ${keyPath} -out ${certPath} ` +
+      `-days 1 -nodes -subj "/CN=Pass Type ID: pass.com.example.passbook/O=pass-js test"`,
+    { stdio: 'ignore' },
+  );
+  return {
+    certPem: readFileSync(certPath, 'utf8'),
+    keyPem: readFileSync(keyPath, 'utf8'),
+  };
+}
+
+function signedTemplate(style: 'coupon' | 'storeCard' = 'storeCard'): Template {
+  const template = new Template(style, baseFields);
+  template.setCertificate(certPem);
+  template.setPrivateKey(keyPem);
+  return template;
+}
+
+async function addRequiredImages(pass: Pass): Promise<void> {
+  await pass.images.add('icon', icon);
+  await pass.images.add('logo', logo);
+}
+
+function readEntry(buffer: Buffer, filename: string): Buffer {
+  const zip = readZip(buffer);
+  const entry = zip.entries.find(e => e.filename === filename);
+  assert.ok(entry, `${filename} is present`);
+  return zip.getBuffer(entry);
+}
+
+function entryNames(buffer: Buffer): string[] {
+  return readZip(buffer).entries.map(entry => entry.filename);
+}
+
+describe('personalization', () => {
+  before(() => {
+    ({ certPem, keyPem } = makeTestKeypair());
+  });
+
+  it('emits personalization.json and logo when all requirements are met', async () => {
+    const pass = signedTemplate('storeCard').createPass();
+    pass.nfc.message = 'acme-rewards-member';
+    pass.personalization = personalization;
+    await addRequiredImages(pass);
+    await pass.images.add('personalizationLogo', logo);
+
+    const buffer = await pass.asBuffer();
+    const names = entryNames(buffer);
+    assert.ok(names.includes('personalization.json'));
+    assert.ok(names.includes('personalizationLogo.png'));
+
+    assert.deepEqual(
+      JSON.parse(readEntry(buffer, 'personalization.json').toString('utf8')),
+      personalization,
+    );
+
+    const manifest = JSON.parse(
+      readEntry(buffer, 'manifest.json').toString('utf8'),
+    ) as Record<string, string>;
+    assert.ok('personalization.json' in manifest);
+    assert.ok('personalizationLogo.png' in manifest);
+
+    const passJson = JSON.parse(
+      readEntry(buffer, 'pass.json').toString('utf8'),
+    );
+    assert.deepEqual(passJson.nfc, { message: 'acme-rewards-member' });
+  });
+
+  it('strips personalization files unless every requirement is met', async () => {
+    const cases: {
+      name: string;
+      setup(pass: Pass): Promise<void> | void;
+    }[] = [
+      {
+        name: 'missing nfc',
+        async setup(pass) {
+          pass.personalization = personalization;
+          await pass.images.add('personalizationLogo', logo);
+        },
+      },
+      {
+        name: 'missing personalization.json',
+        async setup(pass) {
+          pass.nfc.message = 'acme-rewards-member';
+          await pass.images.add('personalizationLogo', logo);
+        },
+      },
+      {
+        name: 'missing personalizationLogo',
+        setup(pass) {
+          pass.nfc.message = 'acme-rewards-member';
+          pass.personalization = personalization;
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const pass = signedTemplate('storeCard').createPass({
+        serialNumber: `personalization-${testCase.name}`,
+      });
+      await addRequiredImages(pass);
+      await testCase.setup(pass);
+
+      const names = entryNames(await pass.asBuffer());
+      assert.ok(
+        !names.includes('personalization.json'),
+        `${testCase.name}: personalization.json omitted`,
+      );
+      assert.ok(
+        !names.some(name => name.startsWith('personalizationLogo')),
+        `${testCase.name}: personalization logos omitted`,
+      );
+    }
+  });
+
+  it('loads personalization from ZIP templates', async () => {
+    const buffer = writeZip([
+      {
+        path: 'pass.json',
+        data: JSON.stringify({
+          formatVersion: 1,
+          ...baseFields,
+          storeCard: {},
+          nfc: { message: 'template-member' },
+        }),
+      },
+      { path: 'icon.png', data: icon },
+      { path: 'logo.png', data: logo },
+      { path: 'personalizationLogo.png', data: logo },
+      { path: 'personalization.json', data: JSON.stringify(personalization) },
+    ]);
+
+    const template = await Template.fromBuffer(buffer);
+    assert.deepEqual(template.personalization, personalization);
+    assert.ok(template.images.has('personalizationLogo.png'));
+
+    template.setCertificate(certPem);
+    template.setPrivateKey(keyPem);
+    const passBuffer = await template.createPass().asBuffer();
+    assert.ok(entryNames(passBuffer).includes('personalization.json'));
+  });
+
+  it('loads personalization from folder templates', async () => {
+    const folder = mkdtempSync(`${tmpdir()}${path.sep}`);
+    writeFileSync(
+      path.join(folder, 'pass.json'),
+      JSON.stringify({
+        formatVersion: 1,
+        ...baseFields,
+        storeCard: {},
+        nfc: { message: 'folder-member' },
+      }),
+    );
+    writeFileSync(path.join(folder, 'icon.png'), icon);
+    writeFileSync(path.join(folder, 'logo.png'), logo);
+    writeFileSync(path.join(folder, 'personalizationLogo.png'), logo);
+    writeFileSync(
+      path.join(folder, 'personalization.json'),
+      JSON.stringify(personalization),
+    );
+
+    const template = await Template.load(folder);
+    assert.deepEqual(template.personalization, personalization);
+    assert.ok(template.images.has('personalizationLogo.png'));
+  });
+
+  it('validates personalization payloads', () => {
+    const template = signedTemplate('storeCard');
+    assert.throws(() => {
+      template.personalization = {
+        description: 'Join',
+        requiredPersonalizationFields: ['not-a-field'],
+      } as unknown as Personalization;
+    }, /requiredPersonalizationFields\[0\] is invalid/);
+  });
+});

--- a/docs/passkit-generator-gap-analysis.md
+++ b/docs/passkit-generator-gap-analysis.md
@@ -2,10 +2,11 @@
 
 > **📌 Historical baseline (pre-PR #664).** This document describes the
 > gap between pass-js (7.0.1) and passkit-generator v3.5.7 **as of
-> 2026-05-10, before any implementation work landed**. P0, P1, and P2
-> (iOS 18 event-ticket keys, iOS 26 enhanced boarding-pass keys, typed
-> `SemanticTags`, and `upcomingPassInformation`) are **implemented in
-> this PR** — see the PR description for the current state. The
+> 2026-05-10, before any implementation work landed**. P0, P1, P2, and
+> P3 (iOS 18 event-ticket keys, iOS 26 enhanced boarding-pass keys,
+> typed `SemanticTags`, `upcomingPassInformation`, and Personalization)
+> are **implemented in this PR** — see the PR description for the
+> current state. The
 > matrix and priority plan below are preserved as the rationale for
 > the change; do not use them to assess current coverage.
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -99,6 +99,10 @@ export const IMAGES: {
     width: 90,
     height: 90,
   },
+  personalizationLogo: {
+    width: 150,
+    height: 40,
+  },
 };
 
 export const DENSITIES: ReadonlySet<ImageDensity> = new Set(['1x', '2x', '3x']);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,3 +34,7 @@ export type {
   UpcomingPassInformationType,
   UpcomingURLs,
 } from './lib/upcoming-pass-information.js';
+export type {
+  Personalization,
+  RequiredPersonalizationField,
+} from './lib/personalization.js';

--- a/src/lib/base-pass.ts
+++ b/src/lib/base-pass.ts
@@ -15,6 +15,10 @@ import {
   validateUpcomingPassInformationEntries,
   type UpcomingPassInformationEntry,
 } from './upcoming-pass-information.js';
+import {
+  validatePersonalization,
+  type Personalization,
+} from './personalization.js';
 
 const STRUCTURE_FIELDS_SET = new Set([...STRUCTURE_FIELDS, 'nfc']);
 
@@ -22,12 +26,14 @@ export class PassBase extends PassStructure {
   readonly images: PassImages;
   readonly localization: Localizations;
   readonly options: Options | undefined;
+  private personalizationData: Personalization | undefined = undefined;
 
   constructor(
     fields: Partial<ApplePass> = {},
     images?: PassImages,
     localizations?: Localizations,
     options?: Options,
+    personalization?: Personalization,
   ) {
     super(fields);
 
@@ -45,6 +51,8 @@ export class PassBase extends PassStructure {
 
     // copy localizations
     this.localization = new Localizations(localizations);
+
+    this.personalization = personalization;
   }
 
   // Returns the pass.json object (not a string). Any Date anywhere in the
@@ -268,6 +276,22 @@ export class PassBase extends PassStructure {
       return;
     }
     this.fields.semantics = normalizeSemanticTags(v);
+  }
+
+  /**
+   * Contents of `personalization.json`, used by Wallet's NFC reward-card
+   * signup flow. The file is only emitted when the final bundle also has a
+   * serialized NFC dictionary and a `personalizationLogo*.png` asset.
+   */
+  get personalization(): Personalization | undefined {
+    return this.personalizationData;
+  }
+  set personalization(v: Personalization | undefined) {
+    if (!v) {
+      this.personalizationData = undefined;
+      return;
+    }
+    this.personalizationData = validatePersonalization(v);
   }
 
   /**

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -24,7 +24,8 @@ export type ImageType =
   | 'background'
   | 'footer'
   | 'strip'
-  | 'thumbnail';
+  | 'thumbnail'
+  | 'personalizationLogo';
 
 const IMAGES_TYPES = new Set(Object.keys(IMAGES));
 export const IMAGE_FILENAME_REGEX = new RegExp(
@@ -275,6 +276,21 @@ export class PassImages extends Map<string, string | Buffer> {
           throw new TypeError(
             `thumbnail image must have height no larger than ${
               150 * densityMulti
+            }px for ${densityMulti}x density, received ${height}`,
+          );
+        break;
+
+      case 'personalizationLogo':
+        if (width > 150 * densityMulti)
+          throw new TypeError(
+            `personalizationLogo image must have width no larger than ${
+              150 * densityMulti
+            }px for ${densityMulti}x density, received ${width}`,
+          );
+        if (height > 40 * densityMulti)
+          throw new TypeError(
+            `personalizationLogo image must have height no larger than ${
+              40 * densityMulti
             }px for ${densityMulti}x density, received ${height}`,
           );
         break;

--- a/src/lib/personalization.ts
+++ b/src/lib/personalization.ts
@@ -62,6 +62,10 @@ export function validatePersonalization(
     throw new TypeError(
       'personalization.requiredPersonalizationFields must be an array',
     );
+  if (value.requiredPersonalizationFields.length === 0)
+    throw new TypeError(
+      'personalization.requiredPersonalizationFields must contain at least one field',
+    );
 
   const requiredPersonalizationFields = value.requiredPersonalizationFields.map(
     (field, index) => {

--- a/src/lib/personalization.ts
+++ b/src/lib/personalization.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2017-2026 Konstantin Vyatkin <tino@vtkn.io>
+
+import { stripJsonComments } from './strip-json-comments.js';
+
+/**
+ * PassKit personalization fields supported by Wallet's reward-card signup
+ * flow.
+ *
+ * @see {@link https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/PassKit_PG/PassPersonalization.html}
+ */
+export type RequiredPersonalizationField =
+  | 'PKPassPersonalizationFieldName'
+  | 'PKPassPersonalizationFieldPostalCode'
+  | 'PKPassPersonalizationFieldEmailAddress'
+  | 'PKPassPersonalizationFieldPhoneNumber';
+
+/**
+ * Contents of `personalization.json`.
+ */
+export interface Personalization {
+  description: string;
+  requiredPersonalizationFields: RequiredPersonalizationField[];
+  termsAndConditions?: string;
+}
+
+const PERSONALIZATION_FIELDS: ReadonlySet<string> = new Set([
+  'PKPassPersonalizationFieldName',
+  'PKPassPersonalizationFieldPostalCode',
+  'PKPassPersonalizationFieldEmailAddress',
+  'PKPassPersonalizationFieldPhoneNumber',
+]);
+
+const PERSONALIZATION_LOGO_RE = /(?:^|\/)personalizationLogo(?:@[23]x)?\.png$/;
+
+function assertPlainObject(value: unknown): asserts value is {
+  description?: unknown;
+  requiredPersonalizationFields?: unknown;
+  termsAndConditions?: unknown;
+} {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) {
+    throw new TypeError('personalization must be a plain object');
+  }
+}
+
+export function validatePersonalization(
+  value: Personalization,
+): Personalization {
+  assertPlainObject(value);
+
+  if (typeof value.description !== 'string' || value.description.length === 0)
+    throw new TypeError(
+      'personalization.description must be a non-empty string',
+    );
+
+  if (!Array.isArray(value.requiredPersonalizationFields))
+    throw new TypeError(
+      'personalization.requiredPersonalizationFields must be an array',
+    );
+
+  const requiredPersonalizationFields = value.requiredPersonalizationFields.map(
+    (field, index) => {
+      if (typeof field !== 'string' || !PERSONALIZATION_FIELDS.has(field)) {
+        throw new TypeError(
+          `personalization.requiredPersonalizationFields[${index}] is invalid`,
+        );
+      }
+      return field as RequiredPersonalizationField;
+    },
+  );
+
+  const res: Personalization = {
+    description: value.description,
+    requiredPersonalizationFields,
+  };
+
+  if (value.termsAndConditions !== undefined) {
+    if (typeof value.termsAndConditions !== 'string')
+      throw new TypeError(
+        'personalization.termsAndConditions must be a string',
+      );
+    res.termsAndConditions = value.termsAndConditions;
+  }
+
+  return res;
+}
+
+export function parsePersonalizationBuffer(buffer: Buffer): Personalization {
+  return validatePersonalization(
+    JSON.parse(stripJsonComments(buffer.toString('utf8'))),
+  );
+}
+
+export function createPersonalizationEntry(personalization: Personalization): {
+  path: 'personalization.json';
+  data: Buffer;
+} {
+  return {
+    path: 'personalization.json',
+    data: Buffer.from(JSON.stringify(validatePersonalization(personalization))),
+  };
+}
+
+export function isPersonalizationLogoPath(path: string): boolean {
+  return PERSONALIZATION_LOGO_RE.test(path);
+}

--- a/src/pass.ts
+++ b/src/pass.ts
@@ -12,6 +12,11 @@ import type { ApplePass, Options } from './interfaces.js';
 import type { Template } from './template.js';
 import type { Localizations } from './lib/localizations.js';
 import { assertUpcomingPassInformationContext } from './lib/upcoming-pass-information.js';
+import {
+  createPersonalizationEntry,
+  isPersonalizationLogoPath,
+  type Personalization,
+} from './lib/personalization.js';
 
 // Create a new pass.
 //
@@ -26,8 +31,9 @@ export class Pass extends PassBase {
     images?: PassImages,
     localization?: Localizations,
     options?: Options,
+    personalization?: Personalization,
   ) {
-    super(fields, images, localization, options);
+    super(fields, images, localization, options, personalization);
     this.template = template;
 
     Object.preventExtensions(this);
@@ -81,9 +87,29 @@ export class Pass extends PassBase {
 
     const zip: ZipWriteEntry[] = [];
 
-    zip.push({ path: 'pass.json', data: Buffer.from(JSON.stringify(this)) });
+    const passJson = JSON.stringify(this);
+    const passObject = JSON.parse(passJson) as Partial<ApplePass>;
+    const imageEntries = await this.images.toArray();
+    const personalization = this.personalization;
+    const hasNfc =
+      'nfc' in passObject &&
+      typeof passObject.nfc === 'object' &&
+      passObject.nfc !== null;
+    const canPersonalize = Boolean(
+      personalization &&
+      hasNfc &&
+      imageEntries.some(entry => isPersonalizationLogoPath(entry.path)),
+    );
+
+    zip.push({ path: 'pass.json', data: Buffer.from(passJson) });
     zip.push(...this.localization.toArray());
-    zip.push(...(await this.images.toArray()));
+    zip.push(
+      ...imageEntries.filter(
+        entry => canPersonalize || !isPersonalizationLogoPath(entry.path),
+      ),
+    );
+    if (canPersonalize && personalization)
+      zip.push(createPersonalizationEntry(personalization));
 
     const manifestJson = JSON.stringify(
       zip.reduce<Record<string, string>>((res, { path, data }) => {

--- a/src/pass.ts
+++ b/src/pass.ts
@@ -18,6 +18,13 @@ import {
   type Personalization,
 } from './lib/personalization.js';
 
+function hasNfcPayload(pass: Partial<ApplePass>): boolean {
+  const nfc = (pass as { nfc?: unknown }).nfc;
+  if (!nfc || typeof nfc !== 'object') return false;
+  const message = (nfc as { message?: unknown }).message;
+  return typeof message === 'string' && message.length > 0;
+}
+
 // Create a new pass.
 //
 // template  - The template
@@ -91,13 +98,9 @@ export class Pass extends PassBase {
     const passObject = JSON.parse(passJson) as Partial<ApplePass>;
     const imageEntries = await this.images.toArray();
     const personalization = this.personalization;
-    const hasNfc =
-      'nfc' in passObject &&
-      typeof passObject.nfc === 'object' &&
-      passObject.nfc !== null;
     const canPersonalize = Boolean(
       personalization &&
-      hasNfc &&
+      hasNfcPayload(passObject) &&
       imageEntries.some(entry => isPersonalizationLogoPath(entry.path)),
     );
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -16,6 +16,10 @@ import { readZip } from './lib/zip.js';
 import type { PassImages } from './lib/images.js';
 import type { Localizations } from './lib/localizations.js';
 import { stripJsonComments } from './lib/strip-json-comments.js';
+import {
+  parsePersonalizationBuffer,
+  type Personalization,
+} from './lib/personalization.js';
 
 const {
   HTTP2_HEADER_METHOD,
@@ -35,8 +39,9 @@ export class Template extends PassBase {
     images?: PassImages,
     localization?: Localizations,
     options?: Options,
+    personalization?: Personalization,
   ) {
-    super(fields, images, localization, options);
+    super(fields, images, localization, options, personalization);
 
     if (style) {
       if (!PASS_STYLES.has(style))
@@ -116,6 +121,14 @@ export class Template extends PassBase {
             );
         }
       } else {
+        if (entry.name === 'personalization.json') {
+          entriesLoader.push(
+            readFile(join(folderPath, entry.name)).then(buffer => {
+              template.personalization = parsePersonalizationBuffer(buffer);
+            }),
+          );
+          continue;
+        }
         if (entry.name === keyName) {
           entriesLoader.push(
             template.loadCertificate(join(folderPath, keyName), keyPassword),
@@ -178,6 +191,11 @@ export class Template extends PassBase {
           template.images,
           template.localization,
           options,
+          template.personalization,
+        );
+      } else if (/(?:^|\/)personalization\.json$/i.test(entry.filename)) {
+        template.personalization = parsePersonalizationBuffer(
+          zip.getBuffer(entry),
         );
       } else {
         const img = template.images.parseFilename(entry.filename);
@@ -325,6 +343,7 @@ export class Template extends PassBase {
       this.images,
       this.localization,
       this.options,
+      this.personalization,
     );
   }
 }


### PR DESCRIPTION
## Summary

Adds PassKit Personalization support for NFC reward-card signup flows.

- Adds typed `Personalization` and `RequiredPersonalizationField` exports for `personalization.json`.
- Adds `template.personalization` / `pass.personalization`, with folder and ZIP template loading support.
- Adds `personalizationLogo*.png` image recognition and 150 x 40 point validation.
- Emits personalization files only when the final pass has NFC data, personalization metadata, and at least one personalization logo; otherwise personalization assets are omitted from the generated bundle.
- Documents the new API and updates the gap analysis note.

## Validation

- `npm run lint`
- `npm test`
- Pre-push hook also ran `npm test` successfully before branch push.

## Notes

The existing local `.vscode/settings.json` change was intentionally left unstaged and is not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for NFC reward-card personalization metadata, including exported personalization types and conditional packaging
  * Personalization logo imagery with size/density validation and inclusion rules

* **Documentation**
  * README updated with personalization examples and packaging requirements
  * Gap analysis note updated

* **Tests**
  * New and expanded tests covering personalization packaging, image validation, template loading, and omission cases

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinovyatkin/pass-js/pull/671)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->