### PR TITLE
feat: support calendarEvent top-level pass field

### DIFF
--- a/__tests__/base-pass.ts
+++ b/__tests__/base-pass.ts
@@ -467,6 +467,85 @@ describe('PassBase', () => {
     assert.equal(json.semantics.internationalDocumentsAreVerified, true);
   });
 
+  it('calendarEvent getter/setter + Date normalization', () => {
+    const bp = new PassBase({ eventTicket: {} });
+    assert.equal(bp.calendarEvent, undefined);
+
+    // Date objects serialize to W3C strings, not Date.prototype.toJSON's
+    // ISO 8601 with milliseconds + trailing Z.
+    const start = new Date(Date.UTC(2026, 5, 1, 12, 0, 0));
+    const end = new Date(Date.UTC(2026, 5, 1, 14, 0, 0));
+    bp.calendarEvent = {
+      title: 'Party',
+      location: 'Discovery Meadow',
+      startDate: start,
+      endDate: end,
+    };
+    const json = JSON.parse(JSON.stringify(bp)) as {
+      calendarEvent: {
+        title: string;
+        location: string;
+        startDate: string;
+        endDate: string;
+      };
+    };
+    assert.equal(json.calendarEvent.title, 'Party');
+    assert.equal(json.calendarEvent.location, 'Discovery Meadow');
+    assert.equal(typeof json.calendarEvent.startDate, 'string');
+    assert.equal(typeof json.calendarEvent.endDate, 'string');
+    assert.doesNotMatch(json.calendarEvent.startDate, /\.\d{3}Z$/);
+    assert.match(
+      json.calendarEvent.startDate,
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?(?:[+-]\d{2}:\d{2}|Z)$/,
+    );
+
+    // Pre-formatted W3C strings pass through unchanged.
+    bp.calendarEvent = {
+      title: 'Party',
+      startDate: '2026-06-01T19:00-08:00',
+      endDate: '2026-06-01T23:00-08:00',
+    };
+    const json2 = JSON.parse(JSON.stringify(bp)) as {
+      calendarEvent: { startDate: string; endDate: string };
+    };
+    assert.equal(json2.calendarEvent.startDate, '2026-06-01T19:00-08:00');
+    assert.equal(json2.calendarEvent.endDate, '2026-06-01T23:00-08:00');
+
+    // Missing title throws.
+    assert.throws(() => {
+      bp.calendarEvent = {
+        startDate: '2026-06-01T19:00-08:00',
+        endDate: '2026-06-01T23:00-08:00',
+      } as unknown as NonNullable<typeof bp.calendarEvent>;
+    }, /calendarEvent\.title must be a non-empty string/);
+
+    // Invalid date string throws.
+    assert.throws(() => {
+      bp.calendarEvent = {
+        title: 'Party',
+        startDate: 'not a date',
+        endDate: '2026-06-01T23:00-08:00',
+      };
+    }, /calendarEvent\.startDate must be a valid W3C date string/);
+
+    // Invalid Date throws.
+    assert.throws(() => {
+      bp.calendarEvent = {
+        title: 'Party',
+        startDate: new Date('nope'),
+        endDate: new Date(Date.UTC(2026, 5, 1, 14, 0, 0)),
+      };
+    }, /calendarEvent\.startDate must be a valid Date/);
+
+    // Setting to undefined deletes the field.
+    bp.calendarEvent = undefined;
+    assert.equal(bp.calendarEvent, undefined);
+    const json3 = JSON.parse(JSON.stringify(bp)) as {
+      calendarEvent?: unknown;
+    };
+    assert.equal(json3.calendarEvent, undefined);
+  });
+
   it('color values as RGB triplets', () => {
     const bp = new PassBase();
     assert.doesNotThrow(() => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -193,6 +193,10 @@ export const TOP_LEVEL_FIELDS: {
   relevantDates: {
     type: Array,
   },
+  calendarEvent: {
+    type: Object,
+    templatable: true,
+  },
   // Visual Appearance Keys
   barcodes: {
     type: Array,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -535,6 +535,17 @@ export interface RelevantDateEntry {
 }
 
 /**
+ * Undocumented-in-prose but valid top-level `calendarEvent` field.
+ * @see {@link https://developer.apple.com/documentation/walletpasses/pass/calendarevent}
+ */
+export interface CalendarEvent {
+  title: string;
+  location?: string;
+  startDate: string | Date;
+  endDate: string | Date;
+}
+
+/**
  * Information about where and when a pass is relevant.
  */
 export interface PassRelevanceKeys {
@@ -572,6 +583,12 @@ export interface PassRelevanceKeys {
    * @see {@link https://developer.apple.com/documentation/walletpasses/pass/relevantdates}
    */
   relevantDates?: RelevantDateEntry[];
+  /**
+   * Calendar event associated with the pass. Presented at WWDC 2018.
+   *
+   * @see {@link https://developer.apple.com/documentation/walletpasses/pass/calendarevent}
+   */
+  calendarEvent?: CalendarEvent;
 }
 
 /**

--- a/src/lib/base-pass.ts
+++ b/src/lib/base-pass.ts
@@ -207,6 +207,45 @@ export class PassBase extends PassStructure {
   }
 
   /**
+   * Calendar event associated with the pass. `startDate` / `endDate`
+   * accept either a `Date` or a W3C-formatted string; `Date` values are
+   * serialized to the W3C format by `normalizeDatesDeep` at `toJSON`
+   * time.
+   */
+  get calendarEvent(): ApplePass['calendarEvent'] {
+    return this.fields.calendarEvent;
+  }
+  set calendarEvent(v: ApplePass['calendarEvent']) {
+    if (!v) {
+      delete this.fields.calendarEvent;
+      return;
+    }
+    if (typeof v.title !== 'string' || v.title.length === 0)
+      throw new TypeError(
+        `calendarEvent.title must be a non-empty string, received ${typeof v.title}`,
+      );
+    for (const key of ['startDate', 'endDate'] as const) {
+      const value = v[key];
+      if (value instanceof Date) {
+        if (!Number.isFinite(value.getTime()))
+          throw new TypeError(
+            `calendarEvent.${key} must be a valid Date, received ${value.toString()}`,
+          );
+      } else if (typeof value === 'string') {
+        if (!isValidW3CDateString(value))
+          throw new TypeError(
+            `calendarEvent.${key} must be a valid W3C date string, received ${value}`,
+          );
+      } else {
+        throw new TypeError(
+          `calendarEvent.${key} must be a Date or W3C date string, received ${typeof value}`,
+        );
+      }
+    }
+    this.fields.calendarEvent = v;
+  }
+
+  /**
    * Ordered list of visual style schemes the pass opts into (iOS 18+).
    */
   get preferredStyleSchemes(): ApplePass['preferredStyleSchemes'] {


### PR DESCRIPTION
## Summary
- Adds `CalendarEvent` interface and `ApplePass.calendarEvent` field.
- `PassBase` getter/setter validates input and stores it; `normalizeDatesDeep` handles `Date` → W3C string serialization.
- Tests cover Date & string inputs, invalid values, and deletion.

Closes #177.

Apple docs: https://developer.apple.com/documentation/walletpasses/pass/calendarevent
WWDC 2018 reference: https://developer.apple.com/videos/play/wwdc2018-720/?time=1705

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (new tests included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar event support: Passes can include iOS-style calendar event info (title, start/end dates, optional location) with validation and serialization.

* **Tests**
  * Added test coverage for calendar event validation, serialization, and removal behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinovyatkin/pass-js/pull/672)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->