### PR TITLE
fix: serialize userInfo top-level pass field

### DIFF
--- a/__tests__/base-pass.ts
+++ b/__tests__/base-pass.ts
@@ -195,6 +195,29 @@ describe('PassBase', () => {
     assert.equal(bp.appLaunchURL, undefined);
   });
 
+  it('userInfo round-trips through toJSON and clears on undefined', () => {
+    const bp = new PassBase();
+    assert.equal(bp.userInfo, undefined);
+    bp.userInfo = { foo: 'bar', num: 42, nested: { a: [1, 2, 3] } };
+    assert.deepEqual(bp.userInfo, {
+      foo: 'bar',
+      num: 42,
+      nested: { a: [1, 2, 3] },
+    });
+    const json = JSON.parse(JSON.stringify(bp));
+    assert.deepEqual(json.userInfo, {
+      foo: 'bar',
+      num: 42,
+      nested: { a: [1, 2, 3] },
+    });
+    bp.userInfo = undefined;
+    assert.equal(bp.userInfo, undefined);
+    assert.equal(JSON.parse(JSON.stringify(bp)).userInfo, undefined);
+    // hydration from constructor fields
+    const bp2 = new PassBase({ userInfo: { token: 'xyz' } });
+    assert.deepEqual(bp2.userInfo, { token: 'xyz' });
+  });
+
   it('P0 iOS 18 event-ticket URL setters round-trip', () => {
     const urlFields = [
       'bagPolicyURL',

--- a/__tests__/base-pass.ts
+++ b/__tests__/base-pass.ts
@@ -218,6 +218,18 @@ describe('PassBase', () => {
     assert.deepEqual(bp2.userInfo, { token: 'xyz' });
   });
 
+  it('userInfo is deep-cloned on assignment so callers cannot mutate pass state', () => {
+    const source = { token: 'abc', nested: { roles: ['admin'] } };
+    const bp = new PassBase();
+    bp.userInfo = source;
+    source.token = 'mutated';
+    source.nested.roles.push('extra');
+    assert.deepEqual(bp.userInfo, {
+      token: 'abc',
+      nested: { roles: ['admin'] },
+    });
+  });
+
   it('P0 iOS 18 event-ticket URL setters round-trip', () => {
     const urlFields = [
       'bagPolicyURL',

--- a/__tests__/pass.ts
+++ b/__tests__/pass.ts
@@ -190,6 +190,39 @@ describe('Pass', () => {
       unlinkSync(passFileName);
     }
   });
+
+  it('serializes userInfo into the pkpass bundle (#630)', async () => {
+    const pass = template.createPass(fields);
+    await pass.images.load(path.resolve(__dirname, './resources'));
+    pass.headerFields.add({ key: 'date', value: 'Date', label: 'Nov 1' });
+    pass.userInfo = {
+      favoriteDrink: 'espresso',
+      loyaltyTier: 3,
+      orderHistory: [{ id: 'A' }, { id: 'B' }],
+    };
+    assert.deepEqual(pass.userInfo, {
+      favoriteDrink: 'espresso',
+      loyaltyTier: 3,
+      orderHistory: [{ id: 'A' }, { id: 'B' }],
+    });
+    const tmd = mkdtempSync(`${tmpdir()}${path.sep}`);
+    const passFileName = path.join(
+      tmd,
+      `pass-${randomBytes(10).toString('hex')}.pkpass`,
+    );
+    writeFileSync(passFileName, await pass.asBuffer());
+    try {
+      const raw = unzipEntry(passFileName, 'pass.json').toString('utf8');
+      const parsed = JSON.parse(raw);
+      assert.deepEqual(parsed.userInfo, {
+        favoriteDrink: 'espresso',
+        loyaltyTier: 3,
+        orderHistory: [{ id: 'A' }, { id: 'B' }],
+      });
+    } finally {
+      unlinkSync(passFileName);
+    }
+  });
 });
 
 describe('generated pass bundle', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -224,6 +224,10 @@ export const TOP_LEVEL_FIELDS: {
   semantics: {
     type: Object,
   },
+  userInfo: {
+    type: Object,
+    templatable: true,
+  },
   suppressStripShine: {
     type: Boolean,
     templatable: true,

--- a/src/lib/base-pass.ts
+++ b/src/lib/base-pass.ts
@@ -285,8 +285,13 @@ export class PassBase extends PassStructure {
     return this.fields.userInfo;
   }
   set userInfo(v: ApplePass['userInfo']) {
-    if (v === undefined || v === null) delete this.fields.userInfo;
-    else this.fields.userInfo = v;
+    if (v === undefined || v === null) {
+      delete this.fields.userInfo;
+      return;
+    }
+    // Deep-clone so Template → Pass → caller don't share mutable state
+    // through the shallow spread in Template.createPass.
+    this.fields.userInfo = structuredClone(v);
   }
 
   /**

--- a/src/lib/base-pass.ts
+++ b/src/lib/base-pass.ts
@@ -279,6 +279,17 @@ export class PassBase extends PassStructure {
   }
 
   /**
+   * Custom information for companion apps. Not displayed to the user.
+   */
+  get userInfo(): ApplePass['userInfo'] {
+    return this.fields.userInfo;
+  }
+  set userInfo(v: ApplePass['userInfo']) {
+    if (v === undefined || v === null) delete this.fields.userInfo;
+    else this.fields.userInfo = v;
+  }
+
+  /**
    * Contents of `personalization.json`, used by Wallet's NFC reward-card
    * signup flow. The file is only emitted when the final bundle also has a
    * serialized NFC dictionary and a `personalizationLogo*.png` asset.


### PR DESCRIPTION
## Summary
- Adds `userInfo` to `TOP_LEVEL_FIELDS` so it's recognized as a top-level optional field.
- Adds `PassBase.userInfo` getter/setter; previously assignment silently failed on frozen Pass instances.
- Serialization test confirms the value round-trips into `pass.json`.

Closes #630.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (new test included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a userInfo field in Apple Passes to embed custom metadata; supports templating and mixed types (strings, numbers, arrays/objects) and is included in the generated pass bundle.

* **Tests**
  * Added tests verifying JSON serialization preserves userInfo exactly and that assigned userInfo is deep-cloned to prevent external mutation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinovyatkin/pass-js/pull/673)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->