### PR TITLE
feat: support row key on eventTicket auxiliary fields

### DIFF
--- a/__tests__/fieldsMap.ts
+++ b/__tests__/fieldsMap.ts
@@ -65,3 +65,15 @@ test('FieldsMap Class', () => {
     `[{"key":"testDate","label":"labelDate","value":"${getW3CDateString(date)}"}]`,
   );
 });
+
+test('FieldsMap preserves `row` on add() and toJSON()', () => {
+  const fields = new FieldsMap();
+  fields.add({ key: 'a', value: '1', row: 0 });
+  fields.add({ key: 'b', value: '2', row: 1 });
+  assert.partialDeepStrictEqual(fields.get('a'), { value: '1', row: 0 });
+  assert.partialDeepStrictEqual(fields.get('b'), { value: '2', row: 1 });
+  assert.deepEqual(fields.toJSON(), [
+    { key: 'a', value: '1', row: 0 },
+    { key: 'b', value: '2', row: 1 },
+  ]);
+});

--- a/__tests__/pass.ts
+++ b/__tests__/pass.ts
@@ -164,6 +164,27 @@ describe('Pass', () => {
     assert.deepEqual(JSON.parse(JSON.stringify(t)), expected);
   });
 
+  it('eventTicket auxiliaryFields round-trip `row` key (issue #625)', () => {
+    const eventTemplate = new Template('eventTicket', {
+      passTypeIdentifier: 'pass.com.example.passbook',
+      teamIdentifier: 'MXL',
+    });
+    const pass = eventTemplate.createPass(fields);
+    pass.auxiliaryFields.add({ key: 'a1', label: 'A1', value: '1', row: 0 });
+    pass.auxiliaryFields.add({ key: 'a2', label: 'A2', value: '2', row: 0 });
+    pass.auxiliaryFields.add({ key: 'b1', label: 'B1', value: '3', row: 1 });
+    pass.auxiliaryFields.add({ key: 'b2', label: 'B2', value: '4', row: 1 });
+    const json = JSON.parse(JSON.stringify(pass)) as {
+      eventTicket: { auxiliaryFields: { key: string; row: 0 | 1 }[] };
+    };
+    const aux = json.eventTicket.auxiliaryFields;
+    assert.equal(aux.length, 4);
+    assert.equal(aux.find(f => f.key === 'a1')?.row, 0);
+    assert.equal(aux.find(f => f.key === 'a2')?.row, 0);
+    assert.equal(aux.find(f => f.key === 'b1')?.row, 1);
+    assert.equal(aux.find(f => f.key === 'b2')?.row, 1);
+  });
+
   it('asBuffer returns a buffer with a valid ZIP', async () => {
     const pass = template.createPass(fields);
     await pass.images.load(path.resolve(__dirname, './resources'));

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -303,6 +303,8 @@ export type FieldDescriptor = {
   changeMessage?: string;
   dataDetectorTypes?: DataDetectors[];
   semantics?: SemanticTags;
+  /** eventTicket auxiliaryFields only */
+  row?: 0 | 1;
 } & (
   | {
       value: string;


### PR DESCRIPTION
## Summary
- Adds optional `row: 0 | 1` to `FieldDescriptor` so `eventTicket.auxiliaryFields` can use Apple's two-row layout.
- Serialization already passed the key through; confirmed with a round-trip test.

Closes #625.

Apple docs: https://developer.apple.com/documentation/walletpasses/passfields/auxiliaryfields

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (new tests included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `row` property support for event ticket auxiliary fields, enabling fields to be organized into specific row positions (0 or 1). The property is now correctly preserved during serialization and deserialization operations.

* **Tests**
  * Added comprehensive test coverage for the `row` property functionality in field operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinovyatkin/pass-js/pull/674)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->