### PR TITLE
feat: AddToWalletButton API (placeholder assets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,15 @@ app.use(async (ctx, next) => {
 });
 ```
 
+## "Add to Apple Wallet" button
+
+`getAddToWalletButton({ locale })` returns Apple's localized badge SVG
+as a `Buffer` (falls back to `en-US`). Usage must follow Apple's
+[Add to Apple Wallet guidelines](https://developer.apple.com/wallet/add-to-apple-wallet-guidelines/).
+The repo currently ships a placeholder `en-US.svg`; the maintainer
+needs to drop Apple's branded SVG assets into
+`src/assets/add-to-wallet/` before the next minor release.
+
 ## Troubleshooting with the Console app
 
 If the pass file generates without errors but you can't open it on an iPhone, connect the iPhone to a Mac running macOS 10.14 or later and open the **Console** application. Select your device on the left, then watch for errors emitted while the system tries to add the pass.

--- a/__tests__/add-to-wallet-button.ts
+++ b/__tests__/add-to-wallet-button.ts
@@ -1,0 +1,84 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { renameSync, existsSync } from 'node:fs';
+
+import {
+  getAddToWalletButton,
+  type AddToWalletLocale,
+} from '../dist/add-to-wallet-button.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ASSET_DIR = path.resolve(__dirname, '../dist/assets/add-to-wallet');
+const EN_US = path.join(ASSET_DIR, 'en-US.svg');
+const EN_US_BAK = path.join(ASSET_DIR, 'en-US.svg.bak');
+
+function looksLikeSvg(buf: Buffer): boolean {
+  const head = buf.subarray(0, 256).toString('utf8').trimStart();
+  return head.startsWith('<?xml') || head.startsWith('<svg');
+}
+
+describe('getAddToWalletButton', () => {
+  it('returns a Buffer with SVG bytes when called with no arguments', () => {
+    const buf = getAddToWalletButton();
+    assert.ok(Buffer.isBuffer(buf));
+    assert.ok(buf.length > 0);
+    assert.ok(
+      looksLikeSvg(buf),
+      `expected SVG-like bytes, got: ${buf.subarray(0, 32).toString('utf8')}`,
+    );
+  });
+
+  it('returns the en-US asset for the default locale', () => {
+    const buf = getAddToWalletButton({ locale: 'en-US' });
+    assert.ok(Buffer.isBuffer(buf));
+    assert.ok(looksLikeSvg(buf));
+  });
+
+  it('falls back to en-US when given an unrecognized locale string', () => {
+    // 'xx-ZZ' parses through normalizeLocale but is not in the supported
+    // set, so the resolver should quietly reach for the en-US placeholder.
+    const bogus = getAddToWalletButton({
+      locale: 'xx-ZZ' as unknown as AddToWalletLocale,
+    });
+    const enUs = getAddToWalletButton({ locale: 'en-US' });
+    assert.deepEqual(bogus, enUs);
+  });
+
+  it('falls back to en-US when the locale is syntactically invalid', () => {
+    // A value normalizeLocale outright rejects should not blow up — the
+    // resolver swallows the TypeError and serves the default placeholder.
+    const bogus = getAddToWalletButton({
+      locale: '@not-a-locale' as unknown as AddToWalletLocale,
+    });
+    const enUs = getAddToWalletButton({ locale: 'en-US' });
+    assert.deepEqual(bogus, enUs);
+  });
+
+  it('throws a clear error when the requested supported locale is not on disk', () => {
+    // 'de-DE' is in AddToWalletLocale but the SVG is not yet committed;
+    // the helper is required to surface a maintainer-directed error
+    // instead of silently falling back, so the gap is noisy.
+    assert.throws(
+      () => getAddToWalletButton({ locale: 'de-DE' }),
+      /Apple-branded SVG assets must be added to src\/assets\/add-to-wallet\//,
+    );
+  });
+
+  describe('when the en-US asset is missing', () => {
+    before(() => {
+      if (existsSync(EN_US)) renameSync(EN_US, EN_US_BAK);
+    });
+    after(() => {
+      if (existsSync(EN_US_BAK)) renameSync(EN_US_BAK, EN_US);
+    });
+
+    it('throws a clear error directing the maintainer to add the SVGs', () => {
+      assert.throws(
+        () => getAddToWalletButton(),
+        /Apple-branded SVG assets must be added to src\/assets\/add-to-wallet\//,
+      );
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
     "dist/**/*.js",
     "dist/**/*.d.ts",
     "dist/**/*.d.ts.map",
+    "dist/assets/**/*.svg",
     "bin/passkit-keys"
   ],
   "scripts": {
-    "build": "tsgo --project tsconfig.json",
+    "build": "tsgo --project tsconfig.json && node --input-type=module -e \"import{cpSync,existsSync}from'node:fs';if(existsSync('src/assets'))cpSync('src/assets','dist/assets',{recursive:true,filter:(s)=>!s.endsWith('.md')});\"",
     "lint": "oxlint --type-aware && oxfmt --check src __tests__",
     "format": "oxfmt src __tests__",
     "test": "npm run build && node --enable-source-maps --test \"__tests__/*.ts\"",

--- a/src/add-to-wallet-button.ts
+++ b/src/add-to-wallet-button.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2017-2026 Konstantin Vyatkin <tino@vtkn.io>
+
+/**
+ * "Add to Apple Wallet" button helper.
+ *
+ * Returns the official Apple-branded badge SVG as a Buffer for the
+ * requested locale, or falls back to `en-US` if the requested locale
+ * is not available.
+ *
+ * IMPORTANT — Apple usage guidelines:
+ * The branded SVG assets are trademarks of Apple Inc. and their use is
+ * governed by Apple's Marketing Resources:
+ *   https://developer.apple.com/wallet/add-to-apple-wallet-guidelines/
+ *
+ * This file ships with a clearly-marked placeholder; the maintainer
+ * must source and drop Apple's real branded SVGs into
+ * `src/assets/add-to-wallet/<locale>.svg` before releasing a version
+ * that advertises this helper as production-ready. See
+ * `src/assets/add-to-wallet/README.md` for the licensing constraint.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { normalizeLocale } from './lib/normalize-locale.js';
+
+export type AddToWalletLocale =
+  | 'en-US'
+  | 'en-GB'
+  | 'es-ES'
+  | 'es-MX'
+  | 'fr-FR'
+  | 'fr-CA'
+  | 'de-DE'
+  | 'it-IT'
+  | 'ja-JP'
+  | 'ko-KR'
+  | 'pt-BR'
+  | 'zh-CN'
+  | 'zh-TW'
+  | 'nl-NL'
+  | 'sv-SE'
+  | 'da-DK'
+  | 'no-NO'
+  | 'fi-FI'
+  | 'ru-RU'
+  | 'pl-PL'
+  | 'tr-TR'
+  | 'th-TH'
+  | 'ar-SA'
+  | 'he-IL';
+
+export interface AddToWalletOptions {
+  locale?: AddToWalletLocale;
+}
+
+const DEFAULT_LOCALE: AddToWalletLocale = 'en-US';
+
+const SUPPORTED_LOCALES: ReadonlySet<AddToWalletLocale> =
+  new Set<AddToWalletLocale>([
+    'en-US',
+    'en-GB',
+    'es-ES',
+    'es-MX',
+    'fr-FR',
+    'fr-CA',
+    'de-DE',
+    'it-IT',
+    'ja-JP',
+    'ko-KR',
+    'pt-BR',
+    'zh-CN',
+    'zh-TW',
+    'nl-NL',
+    'sv-SE',
+    'da-DK',
+    'no-NO',
+    'fi-FI',
+    'ru-RU',
+    'pl-PL',
+    'tr-TR',
+    'th-TH',
+    'ar-SA',
+    'he-IL',
+  ]);
+
+function resolveLocale(input: string | undefined): AddToWalletLocale {
+  if (!input) return DEFAULT_LOCALE;
+  let normalized: string;
+  try {
+    normalized = normalizeLocale(input);
+  } catch {
+    return DEFAULT_LOCALE;
+  }
+  return SUPPORTED_LOCALES.has(normalized as AddToWalletLocale)
+    ? (normalized as AddToWalletLocale)
+    : DEFAULT_LOCALE;
+}
+
+/**
+ * Returns the official "Add to Apple Wallet" badge SVG as a Buffer for
+ * the requested locale. If the requested locale is not available, falls
+ * back to `en-US`.
+ *
+ * Must comply with
+ * https://developer.apple.com/wallet/add-to-apple-wallet-guidelines/
+ */
+export function getAddToWalletButton(options?: AddToWalletOptions): Buffer {
+  const locale = resolveLocale(options?.locale);
+  const assetUrl = new URL(
+    `./assets/add-to-wallet/${locale}.svg`,
+    import.meta.url,
+  );
+  try {
+    return readFileSync(fileURLToPath(assetUrl));
+  } catch (cause) {
+    if (
+      cause instanceof Error &&
+      (cause as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      throw new Error(
+        'Apple-branded SVG assets must be added to src/assets/add-to-wallet/ per https://developer.apple.com/wallet/add-to-apple-wallet-guidelines/',
+        { cause },
+      );
+    }
+    throw cause;
+  }
+}

--- a/src/assets/add-to-wallet/README.md
+++ b/src/assets/add-to-wallet/README.md
@@ -1,0 +1,67 @@
+# `Add to Apple Wallet` badge assets
+
+This directory holds the localized SVG badge files served by
+`getAddToWalletButton({ locale })` (exported from
+`@walletpass/pass-js`).
+
+## What you are looking at
+
+**Only a placeholder ships in this repo.** `en-US.svg` is a dashed
+rectangle labeled "PLACEHOLDER" — it exists so the tests and the public
+API surface are real, but it is NOT Apple's badge and must not be used
+in any shipped product.
+
+## Before publishing a minor release
+
+Apple's "Add to Apple Wallet" marks are Apple trademarks. Their use is
+governed by the Apple Marketing Guidelines and the Apple Wallet
+branding rules:
+
+https://developer.apple.com/wallet/add-to-apple-wallet-guidelines/
+
+The maintainer of this repo must:
+
+1.  Read and agree to the linked guidelines. They cover clearspace,
+    minimum size, color variants, disallowed edits, and contexts in
+    which the mark may appear.
+2.  Download the official localized badge bundle from Apple's
+    Marketing Resources page linked above. Apple publishes SVG sources.
+3.  Drop each locale file into this directory with the filename
+    convention `<locale>.svg`, where `<locale>` is a normalized IETF
+    BCP-47 tag that matches one of the values in `AddToWalletLocale`
+    in `src/add-to-wallet-button.ts`. Examples:
+
+        en-US.svg
+        en-GB.svg
+        es-ES.svg
+        es-MX.svg
+        fr-FR.svg
+        fr-CA.svg
+        de-DE.svg
+        ...
+
+    (The full supported list lives in `AddToWalletLocale`. Keep the
+    two in sync.)
+
+## Why the real assets are not in the repo
+
+The author of this library is not Apple and cannot grant a
+sub-license for Apple's marks. Committing the branded SVGs to a
+public GitHub repo would distribute Apple's trademarked artwork
+without Apple's permission and could put downstream consumers in an
+unclear licensing position. Each maintainer / fork owner should
+fetch the assets directly from Apple's guidelines page under their
+own Apple Developer account, keeping the license chain clean.
+
+## Packaging
+
+The build step copies this directory to `dist/assets/add-to-wallet/`
+so bundled consumers get the SVGs alongside the compiled JS. The
+`package.json` `files` array publishes `dist/**/*.svg`; don't rename
+the SVGs without updating that glob.
+
+Bundler integration: the helper uses
+`new URL('./assets/add-to-wallet/<locale>.svg', import.meta.url)` +
+`readFileSync`, which is the esbuild-recognized pattern for
+statically traced assets. Consumers bundling for Lambda / edge
+runtimes should enable their bundler's file-asset handling.

--- a/src/assets/add-to-wallet/en-US.svg
+++ b/src/assets/add-to-wallet/en-US.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- PLACEHOLDER. Replace with Apple's official "Add to Apple Wallet" badge. -->
+<!-- See ./README.md for sourcing + licensing instructions. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="50" viewBox="0 0 160 50">
+  <rect width="160" height="50" fill="none" stroke="#999" stroke-dasharray="4"/>
+  <text x="80" y="30" text-anchor="middle" font-family="system-ui" font-size="12" fill="#999">PLACEHOLDER</text>
+</svg>

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,8 @@ export type {
   Personalization,
   RequiredPersonalizationField,
 } from './lib/personalization.js';
+export { getAddToWalletButton } from './add-to-wallet-button.js';
+export type {
+  AddToWalletLocale,
+  AddToWalletOptions,
+} from './add-to-wallet-button.js';


### PR DESCRIPTION
## Summary
- New public export `getAddToWalletButton({ locale })` returning the "Add to Apple Wallet" badge SVG as a Buffer.
- Locale resolution + en-US fallback.
- Bundler-safe asset loading via `import.meta.url`.

**Draft because:** Apple's official branded SVGs are not committed in this PR. `src/assets/add-to-wallet/README.md` explains the licensing constraint and what needs to be added before merge. Only a clearly-marked `en-US.svg` placeholder is included (for tests).

Refs #76.

Apple guidelines: https://developer.apple.com/wallet/add-to-apple-wallet-guidelines/

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (placeholder-asset tests included)
- [ ] Maintainer to replace placeholder SVGs with Apple-branded assets before un-drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)