### PR TITLE
refactor: use `using` disposable in semantic-tag cycle guard

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -11,6 +11,7 @@
     "typescript/await-thenable": "error",
     "typescript/no-for-in-array": "error",
     "no-unused-vars": "error",
+    "no-underscore-dangle": ["error", { "allow": ["_cycleGuard"] }],
     "typescript/no-unnecessary-type-assertion": "off",
     "typescript/no-unsafe-type-assertion": "off",
     "typescript/no-unsafe-assignment": "off",

--- a/src/lib/semantic-tags.ts
+++ b/src/lib/semantic-tags.ts
@@ -9,6 +9,19 @@ import type {
 
 import { getW3CDateString } from './w3cdate.js';
 
+// Adds `value` to the recursion-path set and returns a `Disposable` that
+// removes it when the enclosing block exits (normal return, throw, or
+// early exit). Used via `using` to guarantee the set is always rebalanced
+// without a manual try/finally.
+function enterPath(onPath: Set<object>, value: object): Disposable {
+  onPath.add(value);
+  return {
+    [Symbol.dispose]() {
+      onPath.delete(value);
+    },
+  };
+}
+
 function normalizeSemanticValue(
   value: SemanticTagValue,
   onPath: Set<object>,
@@ -22,27 +35,19 @@ function normalizeSemanticValue(
   if (Array.isArray(value)) {
     if (onPath.has(value))
       throw new TypeError(`Semantic tags must not contain cyclic references`);
-    onPath.add(value);
-    try {
-      return value.map(v => normalizeSemanticValue(v, onPath));
-    } finally {
-      onPath.delete(value);
-    }
+    using _cycleGuard = enterPath(onPath, value);
+    return value.map(v => normalizeSemanticValue(v, onPath));
   }
 
   // The truthiness check excludes null, because typeof null is 'object'.
   if (value && typeof value === 'object') {
     if (onPath.has(value))
       throw new TypeError(`Semantic tags must not contain cyclic references`);
-    onPath.add(value);
-    try {
-      const result: { [key: string]: SemanticTagValue } = {};
-      for (const [key, nestedValue] of Object.entries(value))
-        result[key] = normalizeSemanticValue(nestedValue, onPath);
-      return result;
-    } finally {
-      onPath.delete(value);
-    }
+    using _cycleGuard = enterPath(onPath, value);
+    const result: { [key: string]: SemanticTagValue } = {};
+    for (const [key, nestedValue] of Object.entries(value))
+      result[key] = normalizeSemanticValue(nestedValue, onPath);
+    return result;
   }
 
   return value;


### PR DESCRIPTION
## Summary

- Replaces the two `try/finally` blocks in `normalizeSemanticValue` with a small `enterPath()` helper that returns a `Disposable` consumed via `using` — the dispose handler removes the current node from the recursion-path set on normal return, throw, and early exit.
- Configures `oxlint`'s `no-underscore-dangle` rule with `allow: ["_cycleGuard"]` so the intentionally-unused `using` binding passes lint without inline disable comments.

Follows the same style as the existing `await using file = await open(...)` call in `src/lib/png-size.ts`.

## Why `_cycleGuard` and not a plain name

The binding is never read — its job is purely the `Symbol.dispose` side-effect at scope exit. Leading `_` signals that intent and keeps `no-unused-vars` / TS `noUnusedLocals` quiet. oxlint's `no-underscore-dangle` doesn't yet have an `allowAfterUsing` option (filed upstream: oxc-project/oxc#22322), so the name is explicitly allow-listed for now.

## Notes on scope

Other `try/catch` blocks in `src/` (`template.ts:236`, `lib/der.ts:174`, `lib/images.ts:139,148`) are error-rewrapping patterns — catch, add context via `cause`, rethrow. `using` doesn't replace catch-and-rewrap, so those are unchanged.

## Test plan

- [x] `npm run build` — clean tsgo compile
- [x] `npm run lint` — 0 warnings, 0 errors
- [x] `npm test` — 134 pass / 1 skipped (the live-APN test requires real Apple creds). Relevant coverage: `semantics shared subtrees are not mistaken for cycles`, `semantics actual cycles still throw`, `rejects invalid Date values in semantics`, `serializes semantic tags at the pass level`, `relevantDates Date entries are normalized to W3C strings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal cyclic reference handling in semantic tag processing with improved resource management patterns.

* **Chores**
  * Updated linting configuration for code consistency standards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tinovyatkin/pass-js/pull/677)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->